### PR TITLE
Issue #34: added missing hashCode() implementations

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2FrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2FrameData.java
@@ -29,10 +29,25 @@ public abstract class AbstractID3v2FrameData {
 		return packAndUnsynchroniseFrameData();
 	}
 	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (unsynchronisation ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof AbstractID3v2FrameData)) return false;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		AbstractID3v2FrameData other = (AbstractID3v2FrameData) obj;
-		if (unsynchronisation != other.unsynchronisation) return false;
+		if (unsynchronisation != other.unsynchronisation)
+			return false;
 		return true;
 	}
 

--- a/src/main/java/com/mpatric/mp3agic/EncodedText.java
+++ b/src/main/java/com/mpatric/mp3agic/EncodedText.java
@@ -198,12 +198,28 @@ public class EncodedText {
 		return characterSetForTextEncoding(textEncoding);
 	}
 	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + textEncoding;
+		result = prime * result + Arrays.hashCode(value);
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof EncodedText)) return false;
-		if (super.equals(obj)) return true;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		EncodedText other = (EncodedText) obj;
-		if (textEncoding != other.textEncoding) return false;
-		if (! Arrays.equals(value, other.value)) return false;
+		if (textEncoding != other.textEncoding)
+			return false;
+		if (!Arrays.equals(value, other.value))
+			return false;
 		return true;
 	}
 	

--- a/src/main/java/com/mpatric/mp3agic/ID3v1Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v1Tag.java
@@ -207,36 +207,62 @@ public class ID3v1Tag implements ID3v1 {
 	public void setComment(String comment) {
 		this.comment = comment;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((album == null) ? 0 : album.hashCode());
+		result = prime * result + ((artist == null) ? 0 : artist.hashCode());
+		result = prime * result + ((comment == null) ? 0 : comment.hashCode());
+		result = prime * result + genre;
+		result = prime * result + ((title == null) ? 0 : title.hashCode());
+		result = prime * result + ((track == null) ? 0 : track.hashCode());
+		result = prime * result + ((year == null) ? 0 : year.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v1Tag)) return false;
-		if (super.equals(obj)) return true;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v1Tag other = (ID3v1Tag) obj;
-		if (genre != other.genre) return false;
-		if (track == null) {
-			if (other.track != null) return false;
-		} else if (other.track == null) return false;
-		else if (! track.equals(other.track)) return false;
-		if (artist == null) {
-			if (other.artist != null) return false;
-		} else if (other.artist == null) return false;
-		else if (! artist.equals(other.artist)) return false;
-		if (title == null) {
-			if (other.title != null) return false;
-		} else if (other.title == null) return false;
-		else if (! title.equals(other.title)) return false;
 		if (album == null) {
-			if (other.album != null) return false;
-		} else if (other.album == null) return false;
-		else if (! album.equals(other.album)) return false;
-		if (year == null) {
-			if (other.year != null) return false;
-		} else if (other.year == null) return false;
-		else if (! year.equals(other.year)) return false;
+			if (other.album != null)
+				return false;
+		} else if (!album.equals(other.album))
+			return false;
+		if (artist == null) {
+			if (other.artist != null)
+				return false;
+		} else if (!artist.equals(other.artist))
+			return false;
 		if (comment == null) {
-			if (other.comment != null) return false;
-		} else if (other.comment == null) return false;
-		else if (! comment.equals(other.comment)) return false;
+			if (other.comment != null)
+				return false;
+		} else if (!comment.equals(other.comment))
+			return false;
+		if (genre != other.genre)
+			return false;
+		if (title == null) {
+			if (other.title != null)
+				return false;
+		} else if (!title.equals(other.title))
+			return false;
+		if (track == null) {
+			if (other.track != null)
+				return false;
+		} else if (!track.equals(other.track))
+			return false;
+		if (year == null) {
+			if (other.year != null)
+				return false;
+		} else if (!year.equals(other.year))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2ChapterFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2ChapterFrameData.java
@@ -157,21 +157,46 @@ public class ID3v2ChapterFrameData extends AbstractID3v2FrameData {
     }
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + endOffset;
+		result = prime * result + endTime;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + startOffset;
+		result = prime * result + startTime;
+		result = prime * result
+				+ ((subframes == null) ? 0 : subframes.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (!super.equals(obj)) return false;
-		if (getClass() != obj.getClass()) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2ChapterFrameData other = (ID3v2ChapterFrameData) obj;
-		if (endOffset != other.endOffset) return false;
-		if (endTime != other.endTime) return false;
+		if (endOffset != other.endOffset)
+			return false;
+		if (endTime != other.endTime)
+			return false;
 		if (id == null) {
-			if (other.id != null) return false;
-		} else if (!id.equals(other.id)) return false;
-		if (startOffset != other.startOffset) return false;
-		if (startTime != other.startTime) return false;
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (startOffset != other.startOffset)
+			return false;
+		if (startTime != other.startTime)
+			return false;
 		if (subframes == null) {
-			if (other.subframes != null) return false;
-		} else if (!subframes.equals(other.subframes)) return false;
+			if (other.subframes != null)
+				return false;
+		} else if (!subframes.equals(other.subframes))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2ChapterTOCFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2ChapterTOCFrameData.java
@@ -10,7 +10,7 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
     protected boolean isRoot;
     protected boolean isOrdered;
     protected String id;
-    protected String[] childs;
+    protected String[] children;
     protected ArrayList<ID3v2Frame> subframes = new ArrayList<ID3v2Frame>();
 
     public ID3v2ChapterTOCFrameData(boolean unsynchronisation) {
@@ -18,12 +18,12 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
     }
 
     public ID3v2ChapterTOCFrameData(boolean unsynchronisation, boolean isRoot, boolean isOrdered,
-            String id, String[] childs) {
+            String id, String[] children) {
         super(unsynchronisation);
         this.isRoot = isRoot;
         this.isOrdered = isOrdered;
         this.id = id;
-        this.childs = childs;
+        this.children = children;
     }
 
     public ID3v2ChapterTOCFrameData(boolean unsynchronisation, byte[] bytes)
@@ -47,10 +47,10 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
 
         int childCount = bb.get(); // TODO: 0xFF -> int = 255; byte = -128;
 
-        childs = new String[childCount];
+        children = new String[childCount];
 
         for (int i = 0; i < childCount; i++) {
-            childs[i] = ByteBufferUtils.extractNullTerminatedString(bb);
+            children[i] = ByteBufferUtils.extractNullTerminatedString(bb);
         }
 
         for (int offset = bb.position(); offset < bytes.length;) {
@@ -70,9 +70,9 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
         bb.put(id.getBytes());
         bb.put((byte) 0);
         bb.put(getFlags());
-        bb.put((byte)childs.length);
+        bb.put((byte)children.length);
         
-        for(String child: childs) {
+        for(String child: children) {
             bb.put(child.getBytes());
             bb.put((byte) 0);
         }
@@ -124,12 +124,22 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
         this.id = id;
     }
 
-    public String[] getChilds() {
-        return childs;
+    public String[] getChildren() {
+        return children;
     }
 
+    public void setChildren(String[] children) {
+        this.children = children;
+    }
+    
+    @Deprecated
+    public String[] getChilds() {
+        return children;
+    }
+
+    @Deprecated
     public void setChilds(String[] childs) {
-        this.childs = childs;
+        this.children = childs;
     }
 
     public ArrayList<ID3v2Frame> getSubframes() {
@@ -144,9 +154,9 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
     protected int getLength() {
         int length = 3;
         if (id != null) length += id.length();
-        if (childs != null) {
-            length += childs.length;
-            for (String child : childs) {
+        if (children != null) {
+            length += children.length;
+            for (String child : children) {
                 length += child.length();
             }
         }
@@ -158,17 +168,6 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
         return length;
     }
 
-    // public boolean equals(Object obj) {
-    // if (! (obj instanceof ID3v2ChapterFrameData)) return false;
-    // if (! super.equals(obj)) return false;
-    // ID3v2ChapterFrameData other = (ID3v2ChapterFrameData) obj;
-    // if (text == null) {
-    // if (other.text != null) return false;
-    // } else if (other.text == null) return false;
-    // else if (! text.equals(other.text)) return false;
-    // return true;
-    // }
-
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -178,8 +177,8 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
         builder.append(isOrdered);
         builder.append(", id=");
         builder.append(id);
-        builder.append(", childs=");
-        builder.append(Arrays.toString(childs));
+        builder.append(", children=");
+        builder.append(Arrays.toString(children));
         builder.append(", subframes=");
         builder.append(subframes);
         builder.append("]");
@@ -187,20 +186,43 @@ public class ID3v2ChapterTOCFrameData extends AbstractID3v2FrameData {
     }
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + Arrays.hashCode(children);
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (isOrdered ? 1231 : 1237);
+		result = prime * result + (isRoot ? 1231 : 1237);
+		result = prime * result
+				+ ((subframes == null) ? 0 : subframes.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (!super.equals(obj)) return false;
-		if (getClass() != obj.getClass()) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2ChapterTOCFrameData other = (ID3v2ChapterTOCFrameData) obj;
-		if (!Arrays.equals(childs, other.childs)) return false;
+		if (!Arrays.equals(children, other.children))
+			return false;
 		if (id == null) {
-			if (other.id != null) return false;
-		} else if (!id.equals(other.id)) return false;
-		if (isOrdered != other.isOrdered) return false;
-		if (isRoot != other.isRoot) return false;
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (isOrdered != other.isOrdered)
+			return false;
+		if (isRoot != other.isRoot)
+			return false;
 		if (subframes == null) {
-			if (other.subframes != null) return false;
-		} else if (!subframes.equals(other.subframes)) return false;
+			if (other.subframes != null)
+				return false;
+		} else if (!subframes.equals(other.subframes))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2CommentFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2CommentFrameData.java
@@ -106,22 +106,42 @@ public class ID3v2CommentFrameData extends AbstractID3v2FrameData {
 		this.description = description;
 	}
 	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((comment == null) ? 0 : comment.hashCode());
+		result = prime * result
+				+ ((description == null) ? 0 : description.hashCode());
+		result = prime * result
+				+ ((language == null) ? 0 : language.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2CommentFrameData)) return false;
-		if (! super.equals(obj)) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2CommentFrameData other = (ID3v2CommentFrameData) obj;
-		if (language == null) {
-			if (other.language != null) return false;
-		} else if (other.language == null) return false;
-		else if (! language.equals(other.language)) return false;
-		if (description == null) {
-			if (other.description != null) return false;
-		} else if (other.description == null) return false;
-		else if (! description.equals(other.description)) return false;
 		if (comment == null) {
-			if (other.comment != null) return false;
-		} else if (other.comment == null) return false;
-		else if (! comment.equals(other.comment)) return false;
+			if (other.comment != null)
+				return false;
+		} else if (!comment.equals(other.comment))
+			return false;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (language == null) {
+			if (other.language != null)
+				return false;
+		} else if (!language.equals(other.language))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2Frame.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2Frame.java
@@ -172,28 +172,59 @@ public class ID3v2Frame {
 	public boolean hasUnsynchronisation() {
 		return unsynchronisation;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (compression ? 1231 : 1237);
+		result = prime * result + Arrays.hashCode(data);
+		result = prime * result + dataLength;
+		result = prime * result + (dataLengthIndicator ? 1231 : 1237);
+		result = prime * result + (encryption ? 1231 : 1237);
+		result = prime * result + (group ? 1231 : 1237);
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (preserveFile ? 1231 : 1237);
+		result = prime * result + (preserveTag ? 1231 : 1237);
+		result = prime * result + (readOnly ? 1231 : 1237);
+		result = prime * result + (unsynchronisation ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2Frame)) return false;
-		if (super.equals(obj)) return true;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2Frame other = (ID3v2Frame) obj;
-		if (dataLength != other.dataLength) return false;
-		if (preserveTag != other.preserveTag) return false;
-		if (preserveFile != other.preserveFile) return false;
-		if (readOnly != other.readOnly) return false;
-		if (group != other.group) return false;
-		if (compression != other.compression) return false;
-		if (encryption != other.encryption) return false;
-		if (unsynchronisation != other.encryption) return false;
-		if (dataLengthIndicator != other.dataLengthIndicator) return false;
+		if (compression != other.compression)
+			return false;
+		if (!Arrays.equals(data, other.data))
+			return false;
+		if (dataLength != other.dataLength)
+			return false;
+		if (dataLengthIndicator != other.dataLengthIndicator)
+			return false;
+		if (encryption != other.encryption)
+			return false;
+		if (group != other.group)
+			return false;
 		if (id == null) {
-			if (other.id != null) return false;
-		} else if (other.id == null) return false;
-		else if (! id.equals(other.id)) return false;
-		if (data == null) {
-			if (other.data != null) return false;
-		} else if (other.data == null) return false;
-		else if (! Arrays.equals(data, other.data)) return false; 
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (preserveFile != other.preserveFile)
+			return false;
+		if (preserveTag != other.preserveTag)
+			return false;
+		if (readOnly != other.readOnly)
+			return false;
+		if (unsynchronisation != other.unsynchronisation)
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2FrameSet.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2FrameSet.java
@@ -33,19 +33,35 @@ public class ID3v2FrameSet {
 	public String toString() {
 		return this.id + ": " + frames.size();
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((frames == null) ? 0 : frames.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2FrameSet)) return false;
-		if (super.equals(obj)) return true;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2FrameSet other = (ID3v2FrameSet) obj;
-		if (id == null) {
-			if (other.id != null) return false;
-		} else if (other.id == null) return false;
-		else if (! id.equals(other.id)) return false;
 		if (frames == null) {
-			if (other.frames != null) return false;
-		} else if (other.frames == null) return false;
-		else if (! frames.equals(other.frames)) return false;
+			if (other.frames != null)
+				return false;
+		} else if (!frames.equals(other.frames))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2PictureFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2PictureFrameData.java
@@ -119,24 +119,43 @@ public class ID3v2PictureFrameData extends AbstractID3v2FrameData {
 	public void setImageData(byte[] imageData) {
 		this.imageData = imageData;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result
+				+ ((description == null) ? 0 : description.hashCode());
+		result = prime * result + Arrays.hashCode(imageData);
+		result = prime * result
+				+ ((mimeType == null) ? 0 : mimeType.hashCode());
+		result = prime * result + pictureType;
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2PictureFrameData)) return false;
-		if (! super.equals(obj)) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2PictureFrameData other = (ID3v2PictureFrameData) obj;
-		if (pictureType != other.pictureType) return false;
-		if (mimeType == null) {
-			if (other.mimeType != null) return false;
-		} else if (other.mimeType == null) return false;
-		else if (! mimeType.equals(other.mimeType)) return false;
 		if (description == null) {
-			if (other.description != null) return false;
-		} else if (other.description == null) return false;
-		else if (! description.equals(other.description)) return false;
-		if (imageData == null) {
-			if (other.imageData != null) return false;
-		} else if (other.imageData == null) return false;
-		else if (! Arrays.equals(imageData, other.imageData)) return false;
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (!Arrays.equals(imageData, other.imageData))
+			return false;
+		if (mimeType == null) {
+			if (other.mimeType != null)
+				return false;
+		} else if (!mimeType.equals(other.mimeType))
+			return false;
+		if (pictureType != other.pictureType)
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2TextFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2TextFrameData.java
@@ -47,15 +47,29 @@ public class ID3v2TextFrameData extends AbstractID3v2FrameData {
 	public void setText(EncodedText text) {
 		this.text = text;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((text == null) ? 0 : text.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2TextFrameData)) return false;
-		if (! super.equals(obj)) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2TextFrameData other = (ID3v2TextFrameData) obj;
 		if (text == null) {
-			if (other.text != null) return false;
-		} else if (other.text == null) return false;
-		else if (! text.equals(other.text)) return false;
+			if (other.text != null)
+				return false;
+		} else if (!text.equals(other.text))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2UrlFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2UrlFrameData.java
@@ -83,18 +83,34 @@ public class ID3v2UrlFrameData extends AbstractID3v2FrameData {
 		this.url = url;
 	}
 	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((description == null) ? 0 : description.hashCode());
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof ID3v2UrlFrameData)) return false;
-		if (! super.equals(obj)) return false;
+		if (this == obj)
+			return true;
+		if (!super.equals(obj))
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		ID3v2UrlFrameData other = (ID3v2UrlFrameData) obj;
-		if (url == null) {
-			if (other.url != null) return false;
-		} else if (other.url == null) return false;
-		else if (! url.equals(other.url)) return false;
 		if (description == null) {
-			if (other.description != null) return false;
-		} else if (other.description == null) return false;
-		else if (! description.equals(other.description)) return false;
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (url == null) {
+			if (other.url != null)
+				return false;
+		} else if (!url.equals(other.url))
+			return false;
 		return true;
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/MutableInteger.java
+++ b/src/main/java/com/mpatric/mp3agic/MutableInteger.java
@@ -19,12 +19,26 @@ public class MutableInteger {
 	public void setValue(int value) {
 		this.value = value;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + value;
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
-		if (! (obj instanceof MutableInteger)) return false;
-		if (super.equals(obj)) return true;
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
 		MutableInteger other = (MutableInteger) obj;
-		if (value != other.value) return false;
+		if (value != other.value)
+			return false;
 		return true;
 	}
 }

--- a/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
+++ b/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
@@ -338,7 +338,7 @@ public class ID3v2TagTest extends TestCase {
 		ID3v2ChapterTOCFrameData tocFrameData = chapterTOCs.get(0);
 		assertEquals("toc1", tocFrameData.getId());
 		String expectedChildren[] = {"ch1", "ch2", "ch3"};
-		assertTrue(Arrays.equals(expectedChildren, tocFrameData.getChilds()));
+		assertTrue(Arrays.equals(expectedChildren, tocFrameData.getChildren()));
 		
 		ArrayList<ID3v2Frame> subFrames = tocFrameData.getSubframes();
 		assertEquals(0, subFrames.size());


### PR DESCRIPTION
Replaces previous pull request #43 .

The equals/hashCode methods have been generated with Eclipse. In addition, the protected `ID3v2ChapterTOCFrameData.childs` property has been renamed to (correct english) `children`. To maintain compatibility, the old accessor methods are still there, but @Deprecated.
