### PR TITLE
Feat/multitag (Issue #41: Support for text information frames with multiple strings in ID3v2.4)

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -723,7 +723,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		}
 	}
 	
-    public ArrayList<ID3v2ChapterFrameData> getChapters() {
+    public List<ID3v2ChapterFrameData> getChapters() {
         if (obseleteFormat) {
             return null;
         }
@@ -731,7 +731,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return extractChapterFrameData(ID_CHAPTER);
     }
     
-    public void setChapters(ArrayList<ID3v2ChapterFrameData> chapters) {
+    public void setChapters(Iterable<ID3v2ChapterFrameData> chapters) {
         if(chapters != null) {
             invalidateDataLength();
             boolean first = true;
@@ -746,7 +746,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         }
     }
 
-    public ArrayList<ID3v2ChapterTOCFrameData> getChapterTOC() {
+    public List<ID3v2ChapterTOCFrameData> getChapterTOC() {
         if (obseleteFormat) {
             return null;
         }
@@ -754,7 +754,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return extractChapterTOCFrameData(ID_CHAPTER_TOC);
     }
     
-    public void setChapterTOC(ArrayList<ID3v2ChapterTOCFrameData> toc) {
+    public void setChapterTOC(Iterable<ID3v2ChapterTOCFrameData> toc) {
         if(toc != null) {
             invalidateDataLength();
             boolean first = true;
@@ -813,11 +813,11 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		}
 	}
 
-    private ArrayList<ID3v2ChapterFrameData> extractChapterFrameData(String id) {
+    private List<ID3v2ChapterFrameData> extractChapterFrameData(String id) {
         ID3v2FrameSet frameSet = frameSets.get(id);
         if (frameSet != null) {
-            ArrayList<ID3v2ChapterFrameData> chapterData = new ArrayList<ID3v2ChapterFrameData>();
             List<ID3v2Frame> frames = frameSet.getFrames();
+            ArrayList<ID3v2ChapterFrameData> chapterData = new ArrayList<ID3v2ChapterFrameData>(frames.size());
             for (ID3v2Frame frame : frames) {
                 ID3v2ChapterFrameData frameData;
                 try {
@@ -833,11 +833,11 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return null;
     }
 
-    private ArrayList<ID3v2ChapterTOCFrameData> extractChapterTOCFrameData(String id) {
+    private List<ID3v2ChapterTOCFrameData> extractChapterTOCFrameData(String id) {
         ID3v2FrameSet frameSet = frameSets.get(id);
         if (frameSet != null) {
-            ArrayList<ID3v2ChapterTOCFrameData> chapterData = new ArrayList<ID3v2ChapterTOCFrameData>();
             List<ID3v2Frame> frames = frameSet.getFrames();
+            ArrayList<ID3v2ChapterTOCFrameData> chapterData = new ArrayList<ID3v2ChapterTOCFrameData>(frames.size());
             for (ID3v2Frame frame : frames) {
                 ID3v2ChapterTOCFrameData frameData;
                 try {

--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -1,6 +1,7 @@
 package com.mpatric.mp3agic;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -147,7 +148,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return currentOffset;
 	}
 
-	protected void addFrame(ID3v2Frame frame, boolean replace) {
+	private void addFrame(ID3v2Frame frame, boolean replace) {
 		ID3v2FrameSet frameSet = frameSets.get(frame.getId());
 		if (frameSet == null) {
 			frameSet = new ID3v2FrameSet(frame.getId());
@@ -291,7 +292,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return version;
 	}
 		
-	protected void invalidateDataLength() {
+	private void invalidateDataLength() {
 		dataLength = 0;
 	}
 
@@ -347,10 +348,18 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return obseleteFormat;
 	}
 
+	protected List<String> splitTextFrameValues(String s) {
+		return (s == null) ? new ArrayList<String>() : Arrays.asList(s);
+	}
+
 	public String getTrack() {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_TRACK_OBSELETE : ID_TRACK);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getTracks() {
+		return splitTextFrameValues(getTrack());
 	}
 
 	public void setTrack(String track) {
@@ -365,6 +374,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_PART_OF_SET_OBSELETE : ID_PART_OF_SET);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getPartOfSets() {
+		return splitTextFrameValues(getPartOfSet());
 	}
 
 	public void setPartOfSet(String partOfSet) {
@@ -394,6 +407,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getGroupings() {
+		return splitTextFrameValues(getGrouping());
+	}
+
 	public void setGrouping(String grouping) {
 		if (grouping != null && grouping.length() > 0) {
 			invalidateDataLength();
@@ -406,6 +423,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_ARTIST_OBSELETE : ID_ARTIST);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getArtists() {
+		return splitTextFrameValues(getArtist());
 	}
 
 	public void setArtist(String artist) {
@@ -422,6 +443,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getAlbumArtists() {
+		return splitTextFrameValues(getAlbumArtist());
+	}
+
 	public void setAlbumArtist(String albumArtist) {
 	if (albumArtist != null && albumArtist.length() > 0) {
 		invalidateDataLength();
@@ -434,6 +459,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_TITLE_OBSELETE : ID_TITLE);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getTitles() {
+		return splitTextFrameValues(getTitle());
 	}
 
 	public void setTitle(String title) {
@@ -450,6 +479,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getAlbums() {
+		return splitTextFrameValues(getAlbum());
+	}
+
 	public void setAlbum(String album) {
 		if (album != null && album.length() > 0) {
 			invalidateDataLength();
@@ -462,6 +495,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_YEAR_OBSELETE : ID_YEAR);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getYears() {
+		return splitTextFrameValues(getYear());
 	}
 
 	public void setYear(String year) {
@@ -524,6 +561,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 	
+	public List<String> getGenreDescriptions() {
+		return splitTextFrameValues(getGenreDescription());
+	}
+
 	public void setGenreDescription(String text) throws IllegalArgumentException {
 		int genreNum = ID3v1Genres.matchGenreDescription(text);
 		if (genreNum < 0) {
@@ -566,6 +607,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getComments() {
+		return splitTextFrameValues(getComment());
+	}
+
 	public void setComment(String comment) {
 		if (comment != null && comment.length() > 0) {
 			invalidateDataLength();
@@ -594,6 +639,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getComposers() {
+		return splitTextFrameValues(getComposer());
+	}
+
 	public void setComposer(String composer) {
 		if (composer != null && composer.length() > 0) {
 			invalidateDataLength();
@@ -606,6 +655,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_PUBLISHER_OBSELETE : ID_PUBLISHER);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getPublishers() {
+		return splitTextFrameValues(getPublisher());
 	}
 
 	public void setPublisher(String publisher) {
@@ -622,6 +675,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getOriginalArtists() {
+		return splitTextFrameValues(getOriginalArtist());
+	}
+
 	public void setOriginalArtist(String originalArtist) {
 		if (originalArtist != null && originalArtist.length() > 0) {
 			invalidateDataLength();
@@ -636,6 +693,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return null;
 	}
 
+	public List<String> getCopyrights() {
+		return splitTextFrameValues(getCopyright());
+	}
+
 	public void setCopyright(String copyright) {
 		if (copyright != null && copyright.length() > 0) {
 			invalidateDataLength();
@@ -648,6 +709,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2UrlFrameData frameData = extractUrlFrameData(obseleteFormat ? ID_URL_OBSELETE : ID_URL);
 		if (frameData != null) return frameData.getUrl();
 		return null;
+	}
+
+	public List<String> getUrls() {
+		return splitTextFrameValues(getUrl());
 	}
 
 	public void setUrl(String url) {
@@ -708,6 +773,10 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_ENCODER_OBSELETE: ID_ENCODER);
 		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
 		return null;
+	}
+
+	public List<String> getEncoders() {
+		return splitTextFrameValues(getEncoder());
 	}
 
 	public void setEncoder(String encoder) {
@@ -784,7 +853,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return null;
     }
 	
-	protected ID3v2TextFrameData extractTextFrameData(String id) {
+	private ID3v2TextFrameData extractTextFrameData(String id) {
 		ID3v2FrameSet frameSet = frameSets.get(id);
 		if (frameSet != null) {
 			ID3v2Frame frame = (ID3v2Frame) frameSet.getFrames().get(0);

--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -147,7 +147,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return currentOffset;
 	}
 
-	private void addFrame(ID3v2Frame frame, boolean replace) {
+	protected void addFrame(ID3v2Frame frame, boolean replace) {
 		ID3v2FrameSet frameSet = frameSets.get(frame.getId());
 		if (frameSet == null) {
 			frameSet = new ID3v2FrameSet(frame.getId());
@@ -291,7 +291,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return version;
 	}
 		
-	private void invalidateDataLength() {
+	protected void invalidateDataLength() {
 		dataLength = 0;
 	}
 
@@ -784,7 +784,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return null;
     }
 	
-	private ID3v2TextFrameData extractTextFrameData(String id) {
+	protected ID3v2TextFrameData extractTextFrameData(String id) {
 		ID3v2FrameSet frameSet = frameSets.get(id);
 		if (frameSet != null) {
 			ID3v2Frame frame = (ID3v2Frame) frameSet.getFrames().get(0);

--- a/src/main/java/com/mpatric/mp3agic/EncodedText.java
+++ b/src/main/java/com/mpatric/mp3agic/EncodedText.java
@@ -64,27 +64,15 @@ public class EncodedText {
 		throw new IllegalArgumentException("Invalid string, could not find appropriate encoding");
 	}
 	
-	public EncodedText(String[] strings) throws IllegalArgumentException {
-		this(joinStrings(strings));
-	}
-	
 	public EncodedText(String string, byte transcodeToTextEncoding) throws IllegalArgumentException, CharacterCodingException {
 		this(string);
 		setTextEncoding(transcodeToTextEncoding, true);
-	}
-	
-	public EncodedText(String[] strings, byte transcodeToTextEncoding) throws IllegalArgumentException, CharacterCodingException {
-		this(joinStrings(strings), transcodeToTextEncoding);
 	}
 	
 	public EncodedText(byte textEncoding, String string) {
 		this.textEncoding = textEncoding;
 		value = stringToBytes(string, characterSetForTextEncoding(textEncoding));
 		this.stripBomAndTerminator();
-	}
-	
-	public EncodedText(byte textEncoding, String[] strings) {
-		this(textEncoding, joinStrings(strings));
 	}
 	
 	public EncodedText(byte[] value) {
@@ -206,14 +194,6 @@ public class EncodedText {
 		}
 	}
 
-	public String[] toStrings() {
-		try {
-			return bytesToStrings(value, characterSetForTextEncoding(textEncoding));
-		} catch (CharacterCodingException e) {
-			return null;
-		}
-	}
-
 	public String getCharacterSet() {
 		return characterSetForTextEncoding(textEncoding);
 	}
@@ -244,17 +224,7 @@ public class EncodedText {
 	}
 	
 	private static String bytesToString(byte[] bytes, String characterSet) throws CharacterCodingException {
-		CharBuffer cbuf = bytesToCharBuffer(bytes, characterSet);
-		String s = cbuf.toString();
-		int length = s.indexOf(0);
-		if (length == -1) return s;
-		return s.substring(0, length);
-	}
-
-	private static String[] bytesToStrings(byte[] bytes, String characterSet) throws CharacterCodingException {
-		CharBuffer cbuf = bytesToCharBuffer(bytes, characterSet);
-		String s = cbuf.toString();
-		return s.split("\0");
+		return bytesToCharBuffer(bytes, characterSet).toString();
 	}
 	
 	protected static CharBuffer bytesToCharBuffer(byte[] bytes, String characterSet) throws CharacterCodingException {
@@ -271,28 +241,10 @@ public class EncodedText {
 		}
 	}
 	
-	private static byte[] stringsToBytes(String[] strings, String characterSet) {
-		try {
-			return charBufferToBytes(CharBuffer.wrap(joinStrings(strings)), characterSet);
-		} catch (CharacterCodingException e) {
-			return null;
-		}
-	}
-	
 	protected static byte[] charBufferToBytes(CharBuffer charBuffer, String characterSet) throws CharacterCodingException {
 		Charset charset = Charset.forName(characterSet);
 		CharsetEncoder encoder = charset.newEncoder();
 		ByteBuffer byteBuffer = encoder.encode(charBuffer);
 		return BufferTools.copyBuffer(byteBuffer.array(), 0, byteBuffer.limit());
-	}
-	
-	private static String joinStrings(String[] strings) {
-		StringBuilder builder = new StringBuilder();
-		for (String s : strings) {
-			if (builder.length() > 0)
-				builder.append("\0");
-			builder.append(s);
-		}
-		return builder.toString();
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2.java
@@ -1,6 +1,5 @@
 package com.mpatric.mp3agic;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -57,11 +56,11 @@ public interface ID3v2 extends ID3v1 {
 	List<String> getGroupings();
 	void setGrouping(String grouping);
 
-	ArrayList<ID3v2ChapterFrameData> getChapters();
-	void setChapters(ArrayList<ID3v2ChapterFrameData> chapters);
+	List<ID3v2ChapterFrameData> getChapters();
+	void setChapters(Iterable<ID3v2ChapterFrameData> chapters);
 	
-	ArrayList<ID3v2ChapterTOCFrameData> getChapterTOC();
-	void setChapterTOC(ArrayList<ID3v2ChapterTOCFrameData> ctoc);
+	List<ID3v2ChapterTOCFrameData> getChapterTOC();
+	void setChapterTOC(Iterable<ID3v2ChapterTOCFrameData> ctoc);
 	
 	String getEncoder();
 	List<String> getEncoders();

--- a/src/main/java/com/mpatric/mp3agic/ID3v2.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2.java
@@ -1,6 +1,7 @@
 package com.mpatric.mp3agic;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public interface ID3v2 extends ID3v1 {
@@ -14,31 +15,46 @@ public interface ID3v2 extends ID3v1 {
 	boolean hasUnsynchronisation();
 	void setUnsynchronisation(boolean unsynchronisation);
 	
+	List<String> getTitles();
+	List<String> getArtists();
+	List<String> getAlbums();
+	List<String> getTracks();
+	List<String> getYears();
+	List<String> getComments();
+	
 	String getComposer();
+	List<String> getComposers();
 	void setComposer(String composer);
 	
 	String getPublisher();
+	List<String> getPublishers();
 	void setPublisher(String publisher);
 	
 	String getOriginalArtist();
+	List<String> getOriginalArtists();
 	void setOriginalArtist(String originalArtist);
 	
 	String getAlbumArtist();
+	List<String> getAlbumArtists();
 	void setAlbumArtist(String albumArtist);
 	
 	String getCopyright();
+	List<String> getCopyrights();
 	void setCopyright(String copyright);
 	
 	String getUrl();
+	List<String> getUrls();
 	void setUrl(String url);
 
 	String getPartOfSet();
+	List<String> getPartOfSets();
 	void setPartOfSet(String partOfSet);
 
 	boolean isCompilation();
 	void setCompilation(boolean compilation);
 
 	String getGrouping();
+	List<String> getGroupings();
 	void setGrouping(String grouping);
 
 	ArrayList<ID3v2ChapterFrameData> getChapters();
@@ -48,6 +64,7 @@ public interface ID3v2 extends ID3v1 {
 	void setChapterTOC(ArrayList<ID3v2ChapterTOCFrameData> ctoc);
 	
 	String getEncoder();
+	List<String> getEncoders();
 	void setEncoder(String encoder);
 	
 	byte[] getAlbumImage();
@@ -65,6 +82,7 @@ public interface ID3v2 extends ID3v1 {
 	 * @param text genre string
 	 */
 	public void setGenreDescription(String text);
+	List<String> getGenreDescriptions();
 	
 	int getDataLength();
 	int getLength();

--- a/src/main/java/com/mpatric/mp3agic/ID3v24.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v24.java
@@ -1,53 +1,20 @@
 package com.mpatric.mp3agic;
 
-import java.util.ArrayList;
-
 public interface ID3v24 extends ID3v2 {
-	String[] getTitles();
-	void setTitles(String[] titles);
-
-	String[] getArtists();
-	void setArtists(String[] artists);
-
-	String[] getAlbums();
-	void setAlbums(String[] albums);
-
-	String[] getTracks();
-	void setTracks(String[] tracks);
-
-	String[] getYears();
-	void setYears(String[] years);
-
-	String[] getGenreDescriptions();
-	void setGenreDescriptions(String[] genreDescriptions);
-
-	String[] getComments();
-	void setComments(String[] comments);
-
-	String[] getComposers();
-	void setComposers(String[] composers);
-
-	String[] getPublishers();
-	void setPublishers(String[] publishers);
-
-	String[] getOriginalArtists();
-	void setOriginalArtists(String[] originalArtists);
-
-	String[] getAlbumArtists();
-	void setAlbumArtists(String[] albumArtists);
-
-	String[] getCopyrights();
-	void setCopyrights(String[] copyrights);
-
-	String[] getUrls();
-	void setUrls(String[] urls);
-
-	String[] getPartOfSets();
-	void setPartOfSets(String[] partOfSets);
-
-	String[] getGroupings();
-	void setGroupings(String[] groupings);
-
-	String[] getEncoders();
-	void setEncoders(String[] encoders);
+	void setTitles(Iterable<String> titles);
+	void setArtists(Iterable<String> artists);
+	void setAlbums(Iterable<String> albums);
+	void setTracks(Iterable<String> tracks);
+	void setYears(Iterable<String> years);
+	void setGenreDescriptions(Iterable<String> genreDescriptions);
+	void setComments(Iterable<String> comments);
+	void setComposers(Iterable<String> composers);
+	void setPublishers(Iterable<String> publishers);
+	void setOriginalArtists(Iterable<String> originalArtists);
+	void setAlbumArtists(Iterable<String> albumArtists);
+	void setCopyrights(Iterable<String> copyrights);
+	void setUrls(Iterable<String> urls);
+	void setPartOfSets(Iterable<String> partOfSets);
+	void setGroupings(Iterable<String> groupings);
+	void setEncoders(Iterable<String> encoders);
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v24.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v24.java
@@ -1,0 +1,53 @@
+package com.mpatric.mp3agic;
+
+import java.util.ArrayList;
+
+public interface ID3v24 extends ID3v2 {
+	String[] getTitles();
+	void setTitles(String[] titles);
+
+	String[] getArtists();
+	void setArtists(String[] artists);
+
+	String[] getAlbums();
+	void setAlbums(String[] albums);
+
+	String[] getTracks();
+	void setTracks(String[] tracks);
+
+	String[] getYears();
+	void setYears(String[] years);
+
+	String[] getGenreDescriptions();
+	void setGenreDescriptions(String[] genreDescriptions);
+
+	String[] getComments();
+	void setComments(String[] comments);
+
+	String[] getComposers();
+	void setComposers(String[] composers);
+
+	String[] getPublishers();
+	void setPublishers(String[] publishers);
+
+	String[] getOriginalArtists();
+	void setOriginalArtists(String[] originalArtists);
+
+	String[] getAlbumArtists();
+	void setAlbumArtists(String[] albumArtists);
+
+	String[] getCopyrights();
+	void setCopyrights(String[] copyrights);
+
+	String[] getUrls();
+	void setUrls(String[] urls);
+
+	String[] getPartOfSets();
+	void setPartOfSets(String[] partOfSets);
+
+	String[] getGroupings();
+	void setGroupings(String[] groupings);
+
+	String[] getEncoders();
+	void setEncoders(String[] encoders);
+}

--- a/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
@@ -1,6 +1,8 @@
 package com.mpatric.mp3agic;
 
+import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class ID3v24Tag extends AbstractID3v2Tag implements ID3v24 {
 
@@ -15,132 +17,73 @@ public class ID3v24Tag extends AbstractID3v2Tag implements ID3v24 {
 		super(buffer);
 	}
 	
-	public String[] getTitles() {
-		return getTextFrameValues(ID_TITLE);
+	@Override
+	public List<String> splitTextFrameValues(String s) {
+		return (s == null) ? new ArrayList<String>() : nsplit(s);
 	}
 
-	public void setTitles(String[] titles) {
-		setTextFrameValues(ID_TITLE, titles);
+	public void setTitles(Iterable<String> titles) {
+		setTitle(njoin(titles));
 	}
 
-	public String[] getArtists() {
-		return getTextFrameValues(ID_ARTIST);
+	public void setArtists(Iterable<String> artists) {
+		setArtist(njoin(artists));
 	}
 
-	public void setArtists(String[] artists) {
-		setTextFrameValues(ID_ARTIST, artists);
+	public void setAlbums(Iterable<String> albums) {
+		setAlbum(njoin(albums));
 	}
 
-	public String[] getAlbums() {
-		return getTextFrameValues(ID_ALBUM);
+	public void setTracks(Iterable<String> tracks) {
+		setTrack(njoin(tracks));
 	}
 
-	public void setAlbums(String[] albums) {
-		setTextFrameValues(ID_ALBUM, albums);
+	public void setYears(Iterable<String> years) {
+		setYear(njoin(years));
 	}
 
-	public String[] getTracks() {
-		return getTextFrameValues(ID_TRACK);
+	public void setGenreDescriptions(Iterable<String> genres) {
+		setGenreDescription(njoin(genres));
 	}
 
-	public void setTracks(String[] tracks) {
-		setTextFrameValues(ID_TRACK, tracks);
+	public void setComments(Iterable<String> comments) {
+		setComment(njoin(comments));
 	}
 
-	public String[] getYears() {
-		return getTextFrameValues(ID_YEAR);
+	public void setComposers(Iterable<String> composers) {
+		setComposer(njoin(composers));
 	}
 
-	public void setYears(String[] years) {
-		setTextFrameValues(ID_YEAR, years);
+	public void setPublishers(Iterable<String> publishers) {
+		setPublisher(njoin(publishers));
 	}
 
-	public String[] getGenreDescriptions() {
-		return getTextFrameValues(ID_GENRE);
+	public void setOriginalArtists(Iterable<String> originalArtists) {
+		setOriginalArtist(njoin(originalArtists));
 	}
 
-	public void setGenreDescriptions(String[] genres) {
-		setTextFrameValues(ID_GENRE, genres);
+	public void setAlbumArtists(Iterable<String> albumArtists) {
+		setAlbumArtist(njoin(albumArtists));
 	}
 
-	public String[] getComments() {
-		return getTextFrameValues(ID_COMMENT);
+	public void setCopyrights(Iterable<String> copyrights) {
+		setCopyright(njoin(copyrights));
 	}
 
-	public void setComments(String[] comments) {
-		setTextFrameValues(ID_COMMENT, comments);
+	public void setUrls(Iterable<String> urls) {
+		setUrl(njoin(urls));
 	}
 
-	public String[] getComposers() {
-		return getTextFrameValues(ID_COMPOSER);
+	public void setPartOfSets(Iterable<String> partOfSets) {
+		setPartOfSet(njoin(partOfSets));
 	}
 
-	public void setComposers(String[] composers) {
-		setTextFrameValues(ID_COMPOSER, composers);
+	public void setGroupings(Iterable<String> groupings) {
+		setGrouping(njoin(groupings));
 	}
 
-	public String[] getPublishers() {
-		return getTextFrameValues(ID_PUBLISHER);
-	}
-
-	public void setPublishers(String[] publishers) {
-		setTextFrameValues(ID_PUBLISHER, publishers);
-	}
-
-	public String[] getOriginalArtists() {
-		return getTextFrameValues(ID_ORIGINAL_ARTIST);
-	}
-
-	public void setOriginalArtists(String[] originalArtists) {
-		setTextFrameValues(ID_ORIGINAL_ARTIST, originalArtists);
-	}
-
-	public String[] getAlbumArtists() {
-		return getTextFrameValues(ID_ALBUM_ARTIST);
-	}
-
-	public void setAlbumArtists(String[] albumArtists) {
-		setTextFrameValues(ID_ALBUM_ARTIST, albumArtists);
-	}
-
-	public String[] getCopyrights() {
-		return getTextFrameValues(ID_COPYRIGHT);
-	}
-
-	public void setCopyrights(String[] copyrights) {
-		setTextFrameValues(ID_COPYRIGHT, copyrights);
-	}
-
-	public String[] getUrls() {
-		return getTextFrameValues(ID_URL);
-	}
-
-	public void setUrls(String[] urls) {
-		setTextFrameValues(ID_URL, urls);
-	}
-
-	public String[] getPartOfSets() {
-		return getTextFrameValues(ID_PART_OF_SET);
-	}
-
-	public void setPartOfSets(String[] partOfSets) {
-		setTextFrameValues(ID_PART_OF_SET, partOfSets);
-	}
-
-	public String[] getGroupings() {
-		return getTextFrameValues(ID_GROUPING);
-	}
-
-	public void setGroupings(String[] groupings) {
-		setTextFrameValues(ID_GROUPING, groupings);
-	}
-
-	public String[] getEncoders() {
-		return getTextFrameValues(ID_ENCODER);
-	}
-
-	public void setEncoders(String[] encoders) {
-		setTextFrameValues(ID_ENCODER, encoders);
+	public void setEncoders(Iterable<String> encoders) {
+		setEncoder(njoin(encoders));
 	}
 
 	protected void unpackFlags(byte[] buffer) {
@@ -169,20 +112,6 @@ public class ID3v24Tag extends AbstractID3v2Tag implements ID3v24 {
 		return new ID3v24Frame(id, data);
 	}
 	
-	private String[] getTextFrameValues(String id) {
-		ID3v2TextFrameData frameData = extractTextFrameData(id);
-		return (frameData == null || frameData.getText() == null) ? null :
-		frameData.getText().toStrings();
-	}
-	
-	private void setTextFrameValues(String id, String[] values) {
-		if (values != null && values.length > 0) {
-			invalidateDataLength();
-			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(values));
-			addFrame(createFrame(id, frameData.toBytes()), true);
-		}
-	}
-	
 	@Override
 	public void setGenreDescription(String text) {
 		ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(text));
@@ -192,5 +121,22 @@ public class ID3v24Tag extends AbstractID3v2Tag implements ID3v24 {
 		}
 		frameSet.clear();
 		frameSet.addFrame(createFrame(ID_GENRE, frameData.toBytes()));
+	}
+
+	private List<String> nsplit(String s) {
+		return (s == null) ? null : Arrays.asList(s.split("\0"));
+	}
+
+	private String njoin(Iterable<String> vals) {
+		if (vals == null)
+			return null;
+
+		StringBuilder b = new StringBuilder("\0");
+		for (String s : vals) {
+			b.append(s);
+			b.append("\0");
+		}
+
+		return b.substring(1);
 	}
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
@@ -1,6 +1,8 @@
 package com.mpatric.mp3agic;
 
-public class ID3v24Tag extends AbstractID3v2Tag {
+import java.util.ArrayList;
+
+public class ID3v24Tag extends AbstractID3v2Tag implements ID3v24 {
 
 	public static final String VERSION = "4.0";
 
@@ -13,6 +15,134 @@ public class ID3v24Tag extends AbstractID3v2Tag {
 		super(buffer);
 	}
 	
+	public String[] getTitles() {
+		return getTextFrameValues(ID_TITLE);
+	}
+
+	public void setTitles(String[] titles) {
+		setTextFrameValues(ID_TITLE, titles);
+	}
+
+	public String[] getArtists() {
+		return getTextFrameValues(ID_ARTIST);
+	}
+
+	public void setArtists(String[] artists) {
+		setTextFrameValues(ID_ARTIST, artists);
+	}
+
+	public String[] getAlbums() {
+		return getTextFrameValues(ID_ALBUM);
+	}
+
+	public void setAlbums(String[] albums) {
+		setTextFrameValues(ID_ALBUM, albums);
+	}
+
+	public String[] getTracks() {
+		return getTextFrameValues(ID_TRACK);
+	}
+
+	public void setTracks(String[] tracks) {
+		setTextFrameValues(ID_TRACK, tracks);
+	}
+
+	public String[] getYears() {
+		return getTextFrameValues(ID_YEAR);
+	}
+
+	public void setYears(String[] years) {
+		setTextFrameValues(ID_YEAR, years);
+	}
+
+	public String[] getGenreDescriptions() {
+		return getTextFrameValues(ID_GENRE);
+	}
+
+	public void setGenreDescriptions(String[] genres) {
+		setTextFrameValues(ID_GENRE, genres);
+	}
+
+	public String[] getComments() {
+		return getTextFrameValues(ID_COMMENT);
+	}
+
+	public void setComments(String[] comments) {
+		setTextFrameValues(ID_COMMENT, comments);
+	}
+
+	public String[] getComposers() {
+		return getTextFrameValues(ID_COMPOSER);
+	}
+
+	public void setComposers(String[] composers) {
+		setTextFrameValues(ID_COMPOSER, composers);
+	}
+
+	public String[] getPublishers() {
+		return getTextFrameValues(ID_PUBLISHER);
+	}
+
+	public void setPublishers(String[] publishers) {
+		setTextFrameValues(ID_PUBLISHER, publishers);
+	}
+
+	public String[] getOriginalArtists() {
+		return getTextFrameValues(ID_ORIGINAL_ARTIST);
+	}
+
+	public void setOriginalArtists(String[] originalArtists) {
+		setTextFrameValues(ID_ORIGINAL_ARTIST, originalArtists);
+	}
+
+	public String[] getAlbumArtists() {
+		return getTextFrameValues(ID_ALBUM_ARTIST);
+	}
+
+	public void setAlbumArtists(String[] albumArtists) {
+		setTextFrameValues(ID_ALBUM_ARTIST, albumArtists);
+	}
+
+	public String[] getCopyrights() {
+		return getTextFrameValues(ID_COPYRIGHT);
+	}
+
+	public void setCopyrights(String[] copyrights) {
+		setTextFrameValues(ID_COPYRIGHT, copyrights);
+	}
+
+	public String[] getUrls() {
+		return getTextFrameValues(ID_URL);
+	}
+
+	public void setUrls(String[] urls) {
+		setTextFrameValues(ID_URL, urls);
+	}
+
+	public String[] getPartOfSets() {
+		return getTextFrameValues(ID_PART_OF_SET);
+	}
+
+	public void setPartOfSets(String[] partOfSets) {
+		setTextFrameValues(ID_PART_OF_SET, partOfSets);
+	}
+
+	public String[] getGroupings() {
+		return getTextFrameValues(ID_GROUPING);
+	}
+
+	public void setGroupings(String[] groupings) {
+		setTextFrameValues(ID_GROUPING, groupings);
+	}
+
+	public String[] getEncoders() {
+		return getTextFrameValues(ID_ENCODER);
+	}
+
+	public void setEncoders(String[] encoders) {
+		setTextFrameValues(ID_ENCODER, encoders);
+	}
+
 	protected void unpackFlags(byte[] buffer) {
 		unsynchronisation = BufferTools.checkBit(buffer[FLAGS_OFFSET], UNSYNCHRONISATION_BIT);
 		extendedHeader = BufferTools.checkBit(buffer[FLAGS_OFFSET], EXTENDED_HEADER_BIT);
@@ -37,6 +167,20 @@ public class ID3v24Tag extends AbstractID3v2Tag {
 	
 	protected ID3v2Frame createFrame(String id, byte[] data) {
 		return new ID3v24Frame(id, data);
+	}
+	
+	private String[] getTextFrameValues(String id) {
+		ID3v2TextFrameData frameData = extractTextFrameData(id);
+		return (frameData == null || frameData.getText() == null) ? null :
+		frameData.getText().toStrings();
+	}
+	
+	private void setTextFrameValues(String id, String[] values) {
+		if (values != null && values.length > 0) {
+			invalidateDataLength();
+			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(values));
+			addFrame(createFrame(id, frameData.toBytes()), true);
+		}
 	}
 	
 	@Override

--- a/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
+++ b/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
@@ -413,6 +413,20 @@ public class ID3v2TagTest extends TestCase {
 		assertEquals("image/png", id3tag.getAlbumImageMimeType());
 	}
 
+	public void testSetMultiValue24Tag() throws Exception {
+		List<String> artists = Arrays.asList("A", "B", "C");
+		byte[] bytes = {0, 0x41, 0, 0x42, 0, 0x43};
+
+		ID3v24 id3tag = new ID3v24Tag();
+		id3tag.setArtists(artists);
+
+		ID3v2FrameSet frameSet = id3tag.getFrameSets().get("TPE1");
+		ID3v2Frame frame = frameSet.getFrames().get(0);
+
+		assertTrue(artists.equals(id3tag.getArtists()));
+		assertTrue(Arrays.equals(frame.getData(), bytes));
+	}
+
 	private void setTagFields(ID3v2 id3tag) throws IOException {
 		id3tag.setTrack("1");
 		id3tag.setArtist("ARTIST");

--- a/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
+++ b/src/test/java/com/mpatric/mp3agic/ID3v2TagTest.java
@@ -1,7 +1,6 @@
 package com.mpatric.mp3agic;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -332,7 +331,7 @@ public class ID3v2TagTest extends TestCase {
 		byte[] buffer = TestHelper.loadFile("src/test/resources/v23tagwithchapters.mp3");
 		ID3v2 id3tag = ID3v2TagFactory.createTag(buffer);
 		
-		ArrayList<ID3v2ChapterTOCFrameData> chapterTOCs = id3tag.getChapterTOC();
+		List<ID3v2ChapterTOCFrameData> chapterTOCs = id3tag.getChapterTOC();
 		assertEquals(1, chapterTOCs.size());
 		
 		ID3v2ChapterTOCFrameData tocFrameData = chapterTOCs.get(0);
@@ -340,7 +339,7 @@ public class ID3v2TagTest extends TestCase {
 		String expectedChildren[] = {"ch1", "ch2", "ch3"};
 		assertTrue(Arrays.equals(expectedChildren, tocFrameData.getChildren()));
 		
-		ArrayList<ID3v2Frame> subFrames = tocFrameData.getSubframes();
+		List<ID3v2Frame> subFrames = tocFrameData.getSubframes();
 		assertEquals(0, subFrames.size());
 	}
 	
@@ -348,7 +347,7 @@ public class ID3v2TagTest extends TestCase {
 		byte[] buffer = TestHelper.loadFile("src/test/resources/v23tagwithchapters.mp3");
 		ID3v2 id3tag = ID3v2TagFactory.createTag(buffer);
 		
-		ArrayList<ID3v2ChapterFrameData> chapters = id3tag.getChapters();
+		List<ID3v2ChapterFrameData> chapters = id3tag.getChapters();
 		assertEquals(3, chapters.size());
 		
 		ID3v2ChapterFrameData chapter1 = chapters.get(0);
@@ -358,7 +357,7 @@ public class ID3v2TagTest extends TestCase {
 		assertEquals(-1, chapter1.getStartOffset());
 		assertEquals(-1, chapter1.getEndOffset());
 		
-		ArrayList<ID3v2Frame> subFrames1 = chapter1.getSubframes();
+		List<ID3v2Frame> subFrames1 = chapter1.getSubframes();
 		assertEquals(1, subFrames1.size());
 		ID3v2Frame subFrame1 = subFrames1.get(0);
 		assertEquals("TIT2", subFrame1.getId());
@@ -372,7 +371,7 @@ public class ID3v2TagTest extends TestCase {
 		assertEquals(-1, chapter2.getStartOffset());
 		assertEquals(-1, chapter2.getEndOffset());
 		
-		ArrayList<ID3v2Frame> subFrames2 = chapter2.getSubframes();
+		List<ID3v2Frame> subFrames2 = chapter2.getSubframes();
 		assertEquals(1, subFrames2.size());
 		ID3v2Frame subFrame2 = subFrames2.get(0);
 		assertEquals("TIT2", subFrame2.getId());
@@ -386,7 +385,7 @@ public class ID3v2TagTest extends TestCase {
 		assertEquals(-1, chapter3.getStartOffset());
 		assertEquals(-1, chapter3.getEndOffset());
 		
-		ArrayList<ID3v2Frame> subFrames3 = chapter3.getSubframes();
+		List<ID3v2Frame> subFrames3 = chapter3.getSubframes();
 		assertEquals(1, subFrames3.size());
 		ID3v2Frame subFrame3 = subFrames3.get(0);
 		assertEquals("TIT2", subFrame3.getId());


### PR DESCRIPTION
I settled on returning `List` from the getters, and taking `Iterable` in the setters. I also took the liberty of changing the signatures on `get/setChapters` and `get/setChapterTOC` to match (the List interface is close enough to ArrayList that this hopefully won't break any existing code).

Note that the plural getters return fixed-size lists (native arrays wrapped via `Arrays.asList`) to avoid unnecessary copying. This should probably be documented, but I'm not sure where.
