### PR TITLE
Allow text frames with encoding type 1 and big endian BOM to be decoded ...

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/EncodedText.java
+++ b/src/main/java/com/mpatric/mp3agic/EncodedText.java
@@ -47,7 +47,14 @@ public class EncodedText {
 	private byte textEncoding;
 	
 	public EncodedText(byte textEncoding, byte[] value) {
-		this.textEncoding = textEncoding;
+		// if encoding type 1 and big endian BOM is present, switch to big endian
+		if ((textEncoding == TEXT_ENCODING_UTF_16) &&
+			(textEncodingForBytesFromBOM(value) == TEXT_ENCODING_UTF_16BE)) {
+			this.textEncoding = TEXT_ENCODING_UTF_16BE;
+		}
+		else {
+			this.textEncoding = textEncoding;
+		}
 		this.value = value;
 		this.stripBomAndTerminator();
 	}

--- a/src/test/java/com/mpatric/mp3agic/EncodedTextTest.java
+++ b/src/test/java/com/mpatric/mp3agic/EncodedTextTest.java
@@ -160,6 +160,14 @@ public class EncodedTextTest extends TestCase {
 		assertEquals(encodedText, encodedText2);
 	}
 	
+	public void testUTF16ShouldDecodeBEWhenSpecifiedInBOM() throws Exception {
+		// id3 v2.2 and 2.3: encoding set to UTF_16 (type 1), but BOM set to big endian, so interpret as UTF_16BE
+		EncodedText encodedText = new EncodedText(EncodedText.TEXT_ENCODING_UTF_16BE, UNICODE_TEST_STRING);
+		byte bytes[] = encodedText.toBytes(true, true);
+		EncodedText encodedText2 = new EncodedText(EncodedText.TEXT_ENCODING_UTF_16, bytes);
+		assertEquals(encodedText, encodedText2);
+	}
+	
 	public void testShouldThrowExceptionWhenEncodingWithInvalidCharacterSet() throws Exception {
 		try {
 			new EncodedText((byte)4, TEST_STRING);


### PR DESCRIPTION
...as big endian.

They're seemingly rare, but I found some v2.3 tags that used a big endian BOM, and noticed they weren't parsing correctly. Per the spec, encoding type 1 can specify a BOM with big endian.

So, added a check to see if there's a BE BOM on text frames when encoding type 1 is used, and switch it to BE if this is the case.
