### PR TITLE
ID3_v2 fields BPM, Grouping, Key and Date added to abstract ID3_v2 as we...

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -14,13 +14,16 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 	public static final String ID_URL = "WXXX";
 	public static final String ID_COPYRIGHT = "TCOP";
 	public static final String ID_ORIGINAL_ARTIST = "TOPE";
+	public static final String ID_BPM = "TBPM";
 	public static final String ID_COMPOSER = "TCOM";
 	public static final String ID_PUBLISHER = "TPUB";
 	public static final String ID_COMMENT = "COMM";
 	public static final String ID_GENRE = "TCON";
 	public static final String ID_YEAR = "TYER";
+	public static final String ID_DATE = "TDAT";
 	public static final String ID_ALBUM = "TALB";
 	public static final String ID_TITLE = "TIT2";
+	public static final String ID_KEY = "TKEY";
 	public static final String ID_ARTIST = "TPE1";
 	public static final String ID_ALBUM_ARTIST = "TPE2";
 	public static final String ID_TRACK = "TRCK";
@@ -34,13 +37,16 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 	public static final String ID_URL_OBSELETE = "WXX";
 	public static final String ID_COPYRIGHT_OBSELETE = "TCR";
 	public static final String ID_ORIGINAL_ARTIST_OBSELETE = "TOA";
+	public static final String ID_BPM_OBSELETE = "TBP";
 	public static final String ID_COMPOSER_OBSELETE = "TCM";
 	public static final String ID_PUBLISHER_OBSELETE = "TBP";
 	public static final String ID_COMMENT_OBSELETE = "COM";
 	public static final String ID_GENRE_OBSELETE = "TCO";
 	public static final String ID_YEAR_OBSELETE = "TYE";
+	public static final String ID_DATE_OBSELETE = "TDA";
 	public static final String ID_ALBUM_OBSELETE = "TAL";
 	public static final String ID_TITLE_OBSELETE = "TT2";
+	public static final String ID_KEY_OBSELETE = "TKE";
 	public static final String ID_ARTIST_OBSELETE = "TP1";
 	public static final String ID_ALBUM_ARTIST_OBSELETE = "TP2";
 	public static final String ID_TRACK_OBSELETE = "TRK";
@@ -147,7 +153,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return currentOffset;
 	}
 
-	private void addFrame(ID3v2Frame frame, boolean replace) {
+	protected void addFrame(ID3v2Frame frame, boolean replace) {
 		ID3v2FrameSet frameSet = frameSets.get(frame.getId());
 		if (frameSet == null) {
 			frameSet = new ID3v2FrameSet(frame.getId());
@@ -291,7 +297,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		return version;
 	}
 		
-	private void invalidateDataLength() {
+	protected void invalidateDataLength() {
 		dataLength = 0;
 	}
 
@@ -472,6 +478,20 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		}
 	}
 	
+	public String getDate() {
+		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_DATE_OBSELETE : ID_DATE);
+		if (frameData != null && frameData.getText() != null) return frameData.getText().toString();
+		return null;
+	}
+
+	public void setDate(String date) {
+		if (date != null && date.length() > 0) {
+			invalidateDataLength();
+			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(date));
+			addFrame(createFrame(ID_DATE, frameData.toBytes()), true);
+		}
+	}
+	
 	private int getGenre(String text) {
 		if (text != null && text.length() > 0) {
 			try {
@@ -501,6 +521,40 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 			addFrame(createFrame(ID_GENRE, frameData.toBytes()), true);
 		} else {
 			// TODO remove frame?
+		}
+	}
+	
+	public int getBPM() {
+		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_BPM_OBSELETE : ID_BPM);
+		if (frameData == null || frameData.getText() == null) {
+			return -1;
+		}
+		return Integer.parseInt(frameData.getText().toString());
+	}
+
+	public void setBPM(int bpm) {
+		if (bpm >= 0) {
+			invalidateDataLength();
+			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(Integer.toString(bpm)));
+			addFrame(createFrame(ID_GENRE, frameData.toBytes()), true);
+		} else {
+			// TODO remove frame?
+		}
+	}
+	
+	public String getKey() {
+		ID3v2TextFrameData frameData = extractTextFrameData(obseleteFormat ? ID_KEY_OBSELETE : ID_KEY);
+		if (frameData == null || frameData.getText() == null) {
+			return null;
+		}
+		return frameData.getText().toString();
+	}
+
+	public void setKey(String key) {
+		if (key != null && key.length() > 0) {
+			invalidateDataLength();
+			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(key));
+			addFrame(createFrame(ID_KEY, frameData.toBytes()), true);
 		}
 	}
 	
@@ -788,7 +842,7 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
         return null;
     }
 	
-	private ID3v2TextFrameData extractTextFrameData(String id) {
+	protected ID3v2TextFrameData extractTextFrameData(String id) {
 		ID3v2FrameSet frameSet = frameSets.get(id);
 		if (frameSet != null) {
 			ID3v2Frame frame = (ID3v2Frame) frameSet.getFrames().get(0);

--- a/src/main/java/com/mpatric/mp3agic/ID3v2.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2.java
@@ -14,6 +14,18 @@ public interface ID3v2 extends ID3v1 {
 	boolean hasUnsynchronisation();
 	void setUnsynchronisation(boolean unsynchronisation);
 	
+	int getBPM();
+	void setBPM(int bpm);
+	
+	String getGrouping();
+	void setGrouping(String key);
+	
+	String getKey();
+	void setKey(String key);
+	
+	String getDate();
+	void setDate(String date);
+	
 	String getComposer();
 	void setComposer(String composer);
 	
@@ -37,10 +49,7 @@ public interface ID3v2 extends ID3v1 {
 
 	boolean isCompilation();
 	void setCompilation(boolean compilation);
-
-	String getGrouping();
-	void setGrouping(String grouping);
-
+	
 	ArrayList<ID3v2ChapterFrameData> getChapters();
 	void setChapters(ArrayList<ID3v2ChapterFrameData> chapters);
 	

--- a/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v24Tag.java
@@ -4,6 +4,8 @@ public class ID3v24Tag extends AbstractID3v2Tag {
 
 	public static final String VERSION = "4.0";
 
+	public static final String ID_RECTIME = "TDRC";
+	
 	public ID3v24Tag() {
 		super();
 		version = VERSION;
@@ -49,4 +51,26 @@ public class ID3v24Tag extends AbstractID3v2Tag {
 		frameSet.clear();
 		frameSet.addFrame(createFrame(ID_GENRE, frameData.toBytes()));
 	}
+	
+	
+	/*
+	 * 'recording time' (TDRC) replaces the deprecated frames 'TDAT - Date', 'TIME - Time', 
+	 * 'TRDA - Recording dates' and 'TYER - Year' in 4.0
+	 */
+	
+	public String getRecordingTime() {
+		ID3v2TextFrameData frameData = extractTextFrameData(ID_RECTIME);
+		if (frameData != null && frameData.getText() != null) 
+			return frameData.getText().toString();
+		return null;
+	}
+
+	public void setRecordingTime(String rec_year) {
+		if (rec_year != null && rec_year.length() > 0) {
+			invalidateDataLength();
+			ID3v2TextFrameData frameData = new ID3v2TextFrameData(useFrameUnsynchronisation(), new EncodedText(rec_year));
+			addFrame(createFrame(ID_RECTIME, frameData.toBytes()), true);
+		}
+	}
+	
 }


### PR DESCRIPTION
...ll as RecordingTime to ID3_v24

Fixed missing opportunity to get and set the ID3_v2 fields
BPM: TBPM (v22: TBP)
Grouping: TIT1 (v22: TT1)
Key: TKEY (v22: TKE)
Date: TDA (v22: TDA)
in ID3v2 and AbstractID3v2Tag and added new field
'recording time' (TDRC) for v24 in ID3v24Tag
