### PR TITLE
Add File constructors to Mp3File

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/FileWrapper.java
+++ b/src/main/java/com/mpatric/mp3agic/FileWrapper.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 public class FileWrapper {
 	
 	protected File file;
-	protected String filename;
 	protected long length;
 	protected long lastModified;
 	
@@ -15,20 +14,25 @@ public class FileWrapper {
 	}
 
 	public FileWrapper(String filename) throws IOException {
-		this.filename = filename;
+		this.file = new File(filename);
 		init();
+	}
+	
+	public FileWrapper(File file) throws IOException {
+		if (file == null) throw new NullPointerException();
+		this.file = file;
+		init();
+	}
+	
+	private void init() throws IOException {
+		if (!file.exists()) throw new FileNotFoundException("File not found " + file.getPath());
+		if (!file.canRead()) throw new IOException("File not readable");
 		length = file.length();
 		lastModified = file.lastModified();
 	}
-
-	private void init() throws IOException {
-		file = new File(filename);
-		if (!file.exists()) throw new FileNotFoundException("File not found " + filename);
-		if (!file.canRead()) throw new IOException("File not readable");
-	}
 	
 	public String getFilename() {
-		return filename;
+		return file.getPath();
 	}
 
 	public long getLength() {

--- a/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
+++ b/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
@@ -1,5 +1,6 @@
 package com.mpatric.mp3agic;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -8,14 +9,16 @@ import com.mpatric.mp3agic.FileWrapper;
 import junit.framework.TestCase;
 
 public class FileWrapperTest extends TestCase {
-
-	private static final String VALID_FILENAME = "src/test/resources/notags.mp3";
+	private static final String fs = File.separator;
+	private static final String VALID_FILENAME = "src" + fs + "test" + fs + "resources" + fs + "notags.mp3";
 	private static final long VALID_FILE_LENGTH = 2869;
 	private static final String NON_EXISTANT_FILENAME = "just-not.there";	
 	private static final String MALFORMED_FILENAME = "malformed.?";
 
 	public void testShouldReadValidFile() throws IOException {
 		FileWrapper fileWrapper = new FileWrapper(VALID_FILENAME);
+		System.out.println(fileWrapper.getFilename());
+		System.out.println(VALID_FILENAME);
 		assertEquals(fileWrapper.getFilename(), VALID_FILENAME);
 		assertTrue(fileWrapper.getLastModified() > 0);
 		assertEquals(fileWrapper.getLength(), VALID_FILE_LENGTH);
@@ -41,7 +44,16 @@ public class FileWrapperTest extends TestCase {
 	
 	public void testShouldFailForNullFilename() throws IOException {
 		try {
-			new FileWrapper(null);
+			new FileWrapper((String)null);
+			fail("NullPointerException expected but not thrown");
+		} catch (NullPointerException e) {
+			// expected
+		}
+	}
+	
+	public void testShouldFailForNullFilenameFile() throws IOException {
+		try {
+			new FileWrapper((java.io.File)null);
 			fail("NullPointerException expected but not thrown");
 		} catch (NullPointerException e) {
 			// expected

--- a/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
+++ b/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
@@ -1,5 +1,6 @@
 package com.mpatric.mp3agic;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Arrays;
@@ -14,20 +15,25 @@ import com.mpatric.mp3agic.UnsupportedTagException;
 import junit.framework.TestCase;
 
 public class Mp3FileTest extends TestCase {
-
-	private static final String MP3_WITH_NO_TAGS = "src/test/resources/notags.mp3";
-	private static final String MP3_WITH_ID3V1_AND_ID3V23_TAGS = "src/test/resources/v1andv23tags.mp3";
-	private static final String MP3_WITH_DUMMY_START_AND_END_FRAMES = "src/test/resources/dummyframes.mp3";
-	private static final String MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS = "src/test/resources/v1andv23andcustomtags.mp3";
-	private static final String MP3_WITH_ID3V23_UNICODE_TAGS = "src/test/resources/v23unicodetags.mp3";
-	private static final String NOT_AN_MP3 = "src/test/resources/notanmp3.mp3";
-	private static final String MP3_WITH_INCOMPLETE_MPEG_FRAME = "src/test/resources/incompletempegframe.mp3";
+	
+	private static final String fs = File.separator;
+	private static final String MP3_WITH_NO_TAGS = "src" + fs + "test" + fs + "resources" + fs + "notags.mp3";
+	private static final String MP3_WITH_ID3V1_AND_ID3V23_TAGS = "src" + fs + "test" + fs + "resources" + fs + "v1andv23tags.mp3";
+	private static final String MP3_WITH_DUMMY_START_AND_END_FRAMES = "src" + fs + "test" + fs + "resources" + fs + "dummyframes.mp3";
+	private static final String MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS = "src" + fs + "test" + fs + "resources" + fs + "v1andv23andcustomtags.mp3";
+	private static final String MP3_WITH_ID3V23_UNICODE_TAGS = "src" + fs + "test" + fs + "resources" + fs + "v23unicodetags.mp3";
+	private static final String NOT_AN_MP3 = "src" + fs + "test" + fs + "resources" + fs + "notanmp3.mp3";
+	private static final String MP3_WITH_INCOMPLETE_MPEG_FRAME = "src" + fs + "test" + fs + "resources" + fs + "incompletempegframe.mp3";
 	
 	public void testShouldLoadMp3WithNoTags() throws IOException, UnsupportedTagException, InvalidDataException {
 		loadAndCheckTestMp3WithNoTags(MP3_WITH_NO_TAGS, 41);
 		loadAndCheckTestMp3WithNoTags(MP3_WITH_NO_TAGS, 256);
 		loadAndCheckTestMp3WithNoTags(MP3_WITH_NO_TAGS, 1024);
 		loadAndCheckTestMp3WithNoTags(MP3_WITH_NO_TAGS, 5000);
+		loadAndCheckTestMp3WithNoTags(new File(MP3_WITH_NO_TAGS), 41);
+		loadAndCheckTestMp3WithNoTags(new File(MP3_WITH_NO_TAGS), 256);
+		loadAndCheckTestMp3WithNoTags(new File(MP3_WITH_NO_TAGS), 1024);
+		loadAndCheckTestMp3WithNoTags(new File(MP3_WITH_NO_TAGS), 5000);
 	}
 	
 	public void testShouldLoadMp3WithId3Tags() throws IOException, UnsupportedTagException, InvalidDataException {
@@ -35,6 +41,10 @@ public class Mp3FileTest extends TestCase {
 		loadAndCheckTestMp3WithTags(MP3_WITH_ID3V1_AND_ID3V23_TAGS, 256);
 		loadAndCheckTestMp3WithTags(MP3_WITH_ID3V1_AND_ID3V23_TAGS, 1024);
 		loadAndCheckTestMp3WithTags(MP3_WITH_ID3V1_AND_ID3V23_TAGS, 5000);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_ID3V1_AND_ID3V23_TAGS), 41);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_ID3V1_AND_ID3V23_TAGS), 256);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_ID3V1_AND_ID3V23_TAGS), 1024);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_ID3V1_AND_ID3V23_TAGS), 5000);
 	}
 	
 	public void testShouldLoadMp3WithFakeStartAndEndFrames() throws IOException, UnsupportedTagException, InvalidDataException {
@@ -42,6 +52,10 @@ public class Mp3FileTest extends TestCase {
 		loadAndCheckTestMp3WithTags(MP3_WITH_DUMMY_START_AND_END_FRAMES, 256);
 		loadAndCheckTestMp3WithTags(MP3_WITH_DUMMY_START_AND_END_FRAMES, 1024);
 		loadAndCheckTestMp3WithTags(MP3_WITH_DUMMY_START_AND_END_FRAMES, 5000);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_DUMMY_START_AND_END_FRAMES), 41);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_DUMMY_START_AND_END_FRAMES), 256);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_DUMMY_START_AND_END_FRAMES), 1024);
+		loadAndCheckTestMp3WithTags(new File(MP3_WITH_DUMMY_START_AND_END_FRAMES), 5000);
 	}
 	
 	public void testShouldLoadMp3WithCustomTag() throws IOException, UnsupportedTagException, InvalidDataException {
@@ -49,6 +63,10 @@ public class Mp3FileTest extends TestCase {
 		loadAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 256);
 		loadAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 1024);
 		loadAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 5000);
+		loadAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 41);
+		loadAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 256);
+		loadAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 1024);
+		loadAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 5000);
 	}
 	
 	public void testShouldThrowExceptionForFileThatIsNotAnMp3() throws Exception {
@@ -60,26 +78,59 @@ public class Mp3FileTest extends TestCase {
 		}
 	}
 	
-	public void testShouldFindProbableStartOfMpegFramesWithPrescan() throws IOException {
-		Mp3FileForTesting mp3file = new Mp3FileForTesting(MP3_WITH_ID3V1_AND_ID3V23_TAGS);
-		assertEquals(0x44B, mp3file.preScanResult);
+	public void testShouldThrowExceptionForFileThatIsNotAnMp3ForFileConstructor() throws Exception {
+		try {
+			new Mp3File(new File(NOT_AN_MP3));
+			fail("InvalidDataException expected but not thrown");
+		} catch (InvalidDataException e) {
+			assertEquals("No mpegs frames found", e.getMessage());
+		}
 	}
 	
+	public void testShouldFindProbableStartOfMpegFramesWithPrescan() throws IOException {
+		Mp3FileForTesting mp3File = new Mp3FileForTesting(MP3_WITH_ID3V1_AND_ID3V23_TAGS);
+		testShouldFindProbableStartOfMpegFramesWithPrescan(mp3File);
+	}
+	
+	public void testShouldFindProbableStartOfMpegFramesWithPrescanForFileConstructor() throws IOException {
+		Mp3FileForTesting mp3File = new Mp3FileForTesting(new File(MP3_WITH_ID3V1_AND_ID3V23_TAGS));
+		testShouldFindProbableStartOfMpegFramesWithPrescan(mp3File);
+	}
+	
+	private void testShouldFindProbableStartOfMpegFramesWithPrescan(Mp3FileForTesting mp3File) {
+		assertEquals(0x44B, mp3File.preScanResult);
+	}
+
 	public void testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile() throws Exception {
-		Mp3File mp3file = new Mp3File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		Mp3File mp3File = new Mp3File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(mp3File);
+	}
+	
+	public void testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFileForFileConstructor() throws Exception {
+		Mp3File mp3File = new Mp3File(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS));
+		testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(mp3File);
+	}
+	
+	private void testShouldThrowExceptionIfSavingMp3WithSameNameAsSourceFile(Mp3File mp3File) throws NotSupportedException, IOException {
+		System.out.println(mp3File.getFilename());
+		System.out.println(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
 		try {
-			mp3file.save(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+			mp3File.save(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
 			fail("IllegalArgumentException expected but not thrown");
 		} catch (IllegalArgumentException e) {
 			assertEquals("Save filename same as source filename", e.getMessage());
 		}
 	}
-	
+
 	public void testShouldSaveLoadedMp3WhichIsEquivalentToOriginal() throws Exception {
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 41);
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 256);
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 1024);
 		copyAndCheckTestMp3WithCustomTag(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS, 5000);
+		copyAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 41);
+		copyAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 256);
+		copyAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 1024);
+		copyAndCheckTestMp3WithCustomTag(new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS), 5000);
 	}
 	
 	public void testShouldLoadAndCheckMp3ContainingUnicodeFields() throws Exception {
@@ -87,6 +138,10 @@ public class Mp3FileTest extends TestCase {
 		loadAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 256);
 		loadAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 1024);
 		loadAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 5000);
+		loadAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 41);
+		loadAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 256);
+		loadAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 1024);
+		loadAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 5000);
 	}
 	
 	public void testShouldSaveLoadedMp3WithUnicodeFieldsWhichIsEquivalentToOriginal() throws Exception {
@@ -94,10 +149,23 @@ public class Mp3FileTest extends TestCase {
 		copyAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 256);
 		copyAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 1024);
 		copyAndCheckTestMp3WithUnicodeFields(MP3_WITH_ID3V23_UNICODE_TAGS, 5000);
+		copyAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 41);
+		copyAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 256);
+		copyAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 1024);
+		copyAndCheckTestMp3WithUnicodeFields(new File(MP3_WITH_ID3V23_UNICODE_TAGS), 5000);
 	}
 	
 	public void testShouldIgnoreIncompleteMpegFrame() throws Exception {
 		Mp3File mp3File = new Mp3File(MP3_WITH_INCOMPLETE_MPEG_FRAME, 256);
+		testShouldIgnoreIncompleteMpegFrame(mp3File);
+	}
+	
+	public void testShouldIgnoreIncompleteMpegFrameForFileConstructor() throws Exception {
+		Mp3File mp3File = new Mp3File(new File(MP3_WITH_INCOMPLETE_MPEG_FRAME), 256);
+		testShouldIgnoreIncompleteMpegFrame(mp3File);
+	}
+	
+	private void testShouldIgnoreIncompleteMpegFrame(Mp3File mp3File) throws Exception {
 		assertEquals(0x44B, mp3File.getXingOffset());
 		assertEquals(0x5EC, mp3File.getStartOffset());
 		assertEquals(0xF17, mp3File.getEndOffset());
@@ -108,15 +176,32 @@ public class Mp3FileTest extends TestCase {
 	
 	public void testShouldInitialiseProperlyWhenNotScanningFile() throws Exception {
 		Mp3File mp3File = new Mp3File(MP3_WITH_INCOMPLETE_MPEG_FRAME, 256, false);
+		testShouldInitialiseProperlyWhenNotScanningFile(mp3File);
+	}
+	
+	public void testShouldInitialiseProperlyWhenNotScanningFileForFileConstructor() throws Exception {
+		Mp3File mp3File = new Mp3File(new File(MP3_WITH_INCOMPLETE_MPEG_FRAME), 256, false);
+		testShouldInitialiseProperlyWhenNotScanningFile(mp3File);
+	}
+	
+	private void testShouldInitialiseProperlyWhenNotScanningFile(Mp3File mp3File) throws Exception {
 		assertTrue(mp3File.hasId3v1Tag());
 		assertTrue(mp3File.hasId3v2Tag());
 	}
 	
 	public void testShouldRemoveId3v1Tag() throws Exception {
 		String filename = MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS;
-		String saveFilename = filename + ".copy";
+		testShouldRemoveId3v1Tag(new Mp3File(filename));
+	}
+	
+	public void testShouldRemoveId3v1TagForFileConstructor() throws Exception {
+		File filename = new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		testShouldRemoveId3v1Tag(new Mp3File(filename));
+	}
+	
+	private void testShouldRemoveId3v1Tag(Mp3File mp3File) throws Exception {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3File = new Mp3File(filename);
 			mp3File.removeId3v1Tag();
 			mp3File.save(saveFilename);
 			Mp3File newMp3File = new Mp3File(saveFilename);
@@ -130,9 +215,17 @@ public class Mp3FileTest extends TestCase {
 	
 	public void testShouldRemoveId3v2Tag() throws Exception {
 		String filename = MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS;
-		String saveFilename = filename + ".copy";
+		testShouldRemoveId3v2Tag(new Mp3File(filename));
+	}
+	
+	public void testShouldRemoveId3v2TagForFileConstructor() throws Exception {
+		File filename = new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		testShouldRemoveId3v2Tag(new Mp3File(filename));
+	}
+	
+	private void testShouldRemoveId3v2Tag(Mp3File mp3File) throws Exception {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3File = new Mp3File(filename);
 			mp3File.removeId3v2Tag();
 			mp3File.save(saveFilename);
 			Mp3File newMp3File = new Mp3File(saveFilename);
@@ -146,9 +239,17 @@ public class Mp3FileTest extends TestCase {
 	
 	public void testShouldRemoveCustomTag() throws Exception {
 		String filename = MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS;
-		String saveFilename = filename + ".copy";
+		testShouldRemoveCustomTag(new Mp3File(filename));
+	}
+	
+	public void testShouldRemoveCustomTagForFileConstructor() throws Exception {
+		File filename = new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		testShouldRemoveCustomTag(new Mp3File(filename));
+	}
+	
+	private void testShouldRemoveCustomTag(Mp3File mp3File) throws Exception {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3File = new Mp3File(filename);
 			mp3File.removeCustomTag();
 			mp3File.save(saveFilename);
 			Mp3File newMp3File = new Mp3File(saveFilename);
@@ -162,9 +263,17 @@ public class Mp3FileTest extends TestCase {
 	
 	public void testShouldRemoveId3v1AndId3v2AndCustomTags() throws Exception {
 		String filename = MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS;
-		String saveFilename = filename + ".copy";
+		testShouldRemoveId3v1AndId3v2AndCustomTags(new Mp3File(filename));
+	}
+	
+	public void testShouldRemoveId3v1AndId3v2AndCustomTagsForFileConstructor() throws Exception {
+		File filename = new File(MP3_WITH_ID3V1_AND_ID3V23_AND_CUSTOM_TAGS);
+		testShouldRemoveId3v1AndId3v2AndCustomTags(new Mp3File(filename));
+	}
+	
+	private void testShouldRemoveId3v1AndId3v2AndCustomTags(Mp3File mp3File) throws Exception {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3File = new Mp3File(filename);
 			mp3File.removeId3v1Tag();
 			mp3File.removeId3v2Tag();
 			mp3File.removeCustomTag();
@@ -179,15 +288,23 @@ public class Mp3FileTest extends TestCase {
 	}
 	
 	private Mp3File copyAndCheckTestMp3WithCustomTag(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException, NotSupportedException {
-		String saveFilename = null;
+		Mp3File mp3File = loadAndCheckTestMp3WithCustomTag(filename, bufferLength);
+		return copyAndCheckTestMp3WithCustomTag(mp3File);
+	}
+	
+	private Mp3File copyAndCheckTestMp3WithCustomTag(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException, NotSupportedException {
+		Mp3File mp3File = loadAndCheckTestMp3WithCustomTag(filename, bufferLength);
+		return copyAndCheckTestMp3WithCustomTag(mp3File);
+	}
+	
+	private Mp3File copyAndCheckTestMp3WithCustomTag(Mp3File mp3File) throws NotSupportedException, IOException, UnsupportedTagException, InvalidDataException {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3file = loadAndCheckTestMp3WithCustomTag(filename, bufferLength);
-			saveFilename = filename + ".copy";
-			mp3file.save(saveFilename);
+			mp3File.save(saveFilename);
 			Mp3File copyMp3file = loadAndCheckTestMp3WithCustomTag(saveFilename, 5000);
-			assertEquals(mp3file.getId3v1Tag(), copyMp3file.getId3v1Tag());
-			assertEquals(mp3file.getId3v2Tag(), copyMp3file.getId3v2Tag());
-			assertTrue(Arrays.equals(mp3file.getCustomTag(), copyMp3file.getCustomTag()));
+			assertEquals(mp3File.getId3v1Tag(), copyMp3file.getId3v1Tag());
+			assertEquals(mp3File.getId3v2Tag(), copyMp3file.getId3v2Tag());
+			assertTrue(Arrays.equals(mp3File.getCustomTag(), copyMp3file.getCustomTag()));
 			return copyMp3file;
 		} finally {
 			TestHelper.deleteFile(saveFilename);
@@ -195,21 +312,38 @@ public class Mp3FileTest extends TestCase {
 	}
 	
 	private Mp3File copyAndCheckTestMp3WithUnicodeFields(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException, NotSupportedException {
-		String saveFilename = null;
+		Mp3File mp3File = loadAndCheckTestMp3WithUnicodeFields(filename, bufferLength);
+		return copyAndCheckTestMp3WithUnicodeFields(mp3File);
+	}
+	
+	private Mp3File copyAndCheckTestMp3WithUnicodeFields(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException, NotSupportedException {
+		Mp3File mp3File = loadAndCheckTestMp3WithUnicodeFields(filename, bufferLength);
+		return copyAndCheckTestMp3WithUnicodeFields(mp3File);
+	}
+	
+	private Mp3File copyAndCheckTestMp3WithUnicodeFields(Mp3File mp3File) throws NotSupportedException, IOException, UnsupportedTagException, InvalidDataException {
+		String saveFilename = mp3File.getFilename() + ".copy";
 		try {
-			Mp3File mp3file = loadAndCheckTestMp3WithUnicodeFields(filename, bufferLength);
-			saveFilename = filename + ".copy";
-			mp3file.save(saveFilename);
+			mp3File.save(saveFilename);
 			Mp3File copyMp3file = loadAndCheckTestMp3WithUnicodeFields(saveFilename, 5000);
-			assertEquals(mp3file.getId3v2Tag(), copyMp3file.getId3v2Tag());
+			assertEquals(mp3File.getId3v2Tag(), copyMp3file.getId3v2Tag());
 			return copyMp3file;
 		} finally {
 			TestHelper.deleteFile(saveFilename);
 		}
 	}
-
+	
 	private Mp3File loadAndCheckTestMp3WithNoTags(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
 		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithNoTags(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithNoTags(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
+		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithNoTags(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithNoTags(Mp3File mp3File) {
 		assertEquals(0x000, mp3File.getXingOffset());
 		assertEquals(0x1A1, mp3File.getStartOffset());
 		assertEquals(0xB34, mp3File.getEndOffset());
@@ -218,9 +352,18 @@ public class Mp3FileTest extends TestCase {
 		assertFalse(mp3File.hasCustomTag());
 		return mp3File;
 	}
-	
+
 	private Mp3File loadAndCheckTestMp3WithTags(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
 		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithTags(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithTags(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
+		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithTags(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithTags(Mp3File mp3File) {
 		assertEquals(0x44B, mp3File.getXingOffset());
 		assertEquals(0x5EC, mp3File.getStartOffset());
 		assertEquals(0xF7F, mp3File.getEndOffset());
@@ -229,9 +372,18 @@ public class Mp3FileTest extends TestCase {
 		assertFalse(mp3File.hasCustomTag());
 		return mp3File;
 	}
-	
+
 	private Mp3File loadAndCheckTestMp3WithUnicodeFields(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
 		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithUnicodeFields(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithUnicodeFields(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
+		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithUnicodeFields(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithUnicodeFields(Mp3File mp3File) {
 		assertEquals(0x0CA, mp3File.getXingOffset());
 		assertEquals(0x26B, mp3File.getStartOffset());
 		assertEquals(0xBFE, mp3File.getEndOffset());
@@ -240,9 +392,18 @@ public class Mp3FileTest extends TestCase {
 		assertFalse(mp3File.hasCustomTag());
 		return mp3File;
 	}
-	
+
 	private Mp3File loadAndCheckTestMp3WithCustomTag(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
 		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithCustomTag(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithCustomTag(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
+		Mp3File mp3File = loadAndCheckTestMp3(filename, bufferLength);
+		return loadAndCheckTestMp3WithCustomTag(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3WithCustomTag(Mp3File mp3File) {
 		assertEquals(0x44B, mp3File.getXingOffset());
 		assertEquals(0x5EC, mp3File.getStartOffset());
 		assertEquals(0xF7F, mp3File.getEndOffset());
@@ -254,6 +415,15 @@ public class Mp3FileTest extends TestCase {
 
 	private Mp3File loadAndCheckTestMp3(String filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
 		Mp3File mp3File = new Mp3File(filename, bufferLength);
+		return loadAndCheckTestMp3(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3(File filename, int bufferLength) throws IOException, UnsupportedTagException, InvalidDataException {
+		Mp3File mp3File = new Mp3File(filename, bufferLength);
+		return loadAndCheckTestMp3(mp3File);
+	}
+	
+	private Mp3File loadAndCheckTestMp3(Mp3File mp3File) {
 		assertTrue(mp3File.hasXingFrame());
 		assertEquals(6, mp3File.getFrameCount());
 		assertEquals(MpegFrame.MPEG_VERSION_1_0, mp3File.getVersion());
@@ -273,12 +443,17 @@ public class Mp3FileTest extends TestCase {
 		assertEquals(156, mp3File.getLengthInMilliseconds());
 		return mp3File;
 	}
-	
+
 	private class Mp3FileForTesting extends Mp3File {
 
 		int preScanResult;
 
 		public Mp3FileForTesting(String filename) throws IOException {
+			RandomAccessFile file = new RandomAccessFile(filename, "r");
+			preScanResult = preScanFile(file);
+		}
+		
+		public Mp3FileForTesting(File filename) throws IOException {
 			RandomAccessFile file = new RandomAccessFile(filename, "r");
 			preScanResult = preScanFile(file);
 		}


### PR DESCRIPTION
Closes https://github.com/mpatric/mp3agic/issues/51

Adds constructors to Mp3File which takes File instead of String:

public Mp3File(File file)
public Mp3File(File file, int bufferLength)
public Mp3File(File file, int bufferLength, boolean scanFile)

Since filepath String is not supplied during construction, it is
determined via file.getPath() method. In order to ensure consistent
behavior independent of how Mp3File was constructed:
- [filename] variable has been removed from Mp3File's superclass
  FileWrapper
- all methods that were referring to it now refer to file.getPath()

In order to prevent file separator related issues ("src/test/x.mp3" is a
valid argument for Mp3File(String filename) constructor, but e.g. on
Windows file.getPath() would return "src\test\x.mp3"):
- Mp3File's save() method now compares File objects instead of String
  filepaths during equality test
- String literals in form of "src/test/x.mp3" in test cases were replaced
  by "src" + fs + "test" + fs + "x.mp3" where [fs] stands for
  File.separator
