### PR TITLE
getBPM now converts from float

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -537,7 +537,13 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		if (frameData == null || frameData.getText() == null) {
 			return -1;
 		}
-		return Integer.parseInt(frameData.getText().toString());
+		String bpmStr = frameData.getText().toString();
+		try {
+			return Integer.parseInt(bpmStr);
+		} catch (NumberFormatException e) {
+			// try float as some utilities add BPM like 67.8, or 67,8
+			return (int)Float.parseFloat(bpmStr.trim().replaceAll(",","."));
+		}
 	}
 
 	public void setBPM(int bpm) {


### PR DESCRIPTION
Some utilities (like BPM converter - freeware) like to add BPM as a float for more accurary - which crashes this library with a NumberFormatException. This simple patch converts from float (also with comma decimal points), back to integer, but only if NumberFormatException occurs on the Integer parsing.