### PR TITLE
Mp3File convenience methods for reading tags

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
+++ b/src/main/java/com/mpatric/mp3agic/AbstractID3v2Tag.java
@@ -538,12 +538,15 @@ public abstract class AbstractID3v2Tag implements ID3v2 {
 		if (frameData == null || frameData.getText() == null) {
 			return -1;
 		}
-		String bpmStr = frameData.getText().toString();
+		String bpmStr = frameData.getText().toString().trim();
+                if (bpmStr.isEmpty()) {
+                    return -1;
+                }
 		try {
 			return Integer.parseInt(bpmStr);
 		} catch (NumberFormatException e) {
 			// try float as some utilities add BPM like 67.8, or 67,8
-			return (int)Float.parseFloat(bpmStr.trim().replaceAll(",","."));
+			return (int)Float.parseFloat(bpmStr.replaceAll(",","."));
 		}
 	}
 

--- a/src/main/java/com/mpatric/mp3agic/ID3v1.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v1.java
@@ -1,30 +1,20 @@
 package com.mpatric.mp3agic;
 
-public interface ID3v1 {
+public interface ID3v1 extends ID3v1Source {
 	
-	String getVersion();
-	
-	String getTrack();
 	void setTrack(String track);
 	
-	String getArtist();
 	void setArtist(String artist);
 	
-	String getTitle();
 	void setTitle(String title);
 	
-	String getAlbum();
 	void setAlbum(String album);
 	
-	String getYear();
 	void setYear(String year);
 	
-	int getGenre();
 	void setGenre(int genre);
-	String getGenreDescription();
-	
-	String getComment();
-	void setComment(String comment);
+
+        void setComment(String comment);
 	
 	byte[] toBytes() throws NotSupportedException;
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v1Source.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v1Source.java
@@ -1,0 +1,23 @@
+package com.mpatric.mp3agic;
+
+public interface ID3v1Source {
+
+    String getAlbum();
+
+    String getArtist();
+
+    String getComment();
+
+    int getGenre();
+
+    String getGenreDescription();
+
+    String getTitle();
+
+    String getTrack();
+
+    String getVersion();
+
+    String getYear();
+
+}

--- a/src/main/java/com/mpatric/mp3agic/ID3v2.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2.java
@@ -1,97 +1,65 @@
 package com.mpatric.mp3agic;
 
 import java.util.ArrayList;
-import java.util.Map;
 
-public interface ID3v2 extends ID3v1 {
+public interface ID3v2 extends ID3v1, ID3v2Source {
 	
-	boolean getPadding();
 	void setPadding(boolean padding);
 	
-	boolean hasFooter();
 	void setFooter(boolean footer);
 	
-	boolean hasUnsynchronisation();
 	void setUnsynchronisation(boolean unsynchronisation);
 	
-	int getBPM();
 	void setBPM(int bpm);
 	
-	String getGrouping();
 	void setGrouping(String grouping);
 	
-	String getKey();
 	void setKey(String key);
 	
-	String getDate();
 	void setDate(String date);
 	
-	String getComposer();
 	void setComposer(String composer);
 	
-	String getPublisher();
 	void setPublisher(String publisher);
 	
-	String getOriginalArtist();
 	void setOriginalArtist(String originalArtist);
 	
-	String getAlbumArtist();
 	void setAlbumArtist(String albumArtist);
 	
-	String getCopyright();
 	void setCopyright(String copyright);
 	
-	String getArtistUrl();
 	void setArtistUrl(String url);
 
-	String getCommercialUrl();
 	void setCommercialUrl(String url);
 
-	String getCopyrightUrl();
 	void setCopyrightUrl(String url);
 
-	String getAudiofileUrl();
 	void setAudiofileUrl(String url);
 
-	String getAudioSourceUrl();
 	void setAudioSourceUrl(String url);
 
-	String getRadiostationUrl();
 	void setRadiostationUrl(String url);
 
-	String getPaymentUrl();
 	void setPaymentUrl(String url);
 
-	String getPublisherUrl();
 	void setPublisherUrl(String url);
 
-	String getUrl();
 	void setUrl(String url);
 
-	String getPartOfSet();
 	void setPartOfSet(String partOfSet);
 
-	boolean isCompilation();
 	void setCompilation(boolean compilation);
 	
-	ArrayList<ID3v2ChapterFrameData> getChapters();
 	void setChapters(ArrayList<ID3v2ChapterFrameData> chapters);
 	
-	ArrayList<ID3v2ChapterTOCFrameData> getChapterTOC();
 	void setChapterTOC(ArrayList<ID3v2ChapterTOCFrameData> ctoc);
 	
-	String getEncoder();
 	void setEncoder(String encoder);
 	
-	byte[] getAlbumImage();
 	void setAlbumImage(byte[] albumImage, String mimeType);
 	void clearAlbumImage();
-	String getAlbumImageMimeType();
-	
-	int getWmpRating();
 	void setWmpRating(int rating);
 	
-	String getItunesComment();
 	void setItunesComment(String itunesComment);
 	
 	/**
@@ -103,10 +71,5 @@ public interface ID3v2 extends ID3v1 {
 	 */
 	public void setGenreDescription(String text);
 	
-	int getDataLength();
-	int getLength();
-	boolean getObseleteFormat();
-	
-	Map<String, ID3v2FrameSet> getFrameSets();
 	void clearFrameSet(String id);
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v2Source.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2Source.java
@@ -1,0 +1,76 @@
+package com.mpatric.mp3agic;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public interface ID3v2Source {
+
+    String getAlbumArtist();
+
+    byte[] getAlbumImage();
+
+    String getAlbumImageMimeType();
+
+    String getArtistUrl();
+
+    String getAudioSourceUrl();
+
+    String getAudiofileUrl();
+
+    int getBPM();
+
+    ArrayList<ID3v2ChapterTOCFrameData> getChapterTOC();
+
+    ArrayList<ID3v2ChapterFrameData> getChapters();
+
+    String getCommercialUrl();
+
+    String getComposer();
+
+    String getCopyright();
+
+    String getCopyrightUrl();
+
+    int getDataLength();
+
+    String getDate();
+
+    String getEncoder();
+
+    Map<String, ID3v2FrameSet> getFrameSets();
+
+    String getGrouping();
+
+    String getItunesComment();
+
+    String getKey();
+
+    int getLength();
+
+    boolean getObseleteFormat();
+
+    String getOriginalArtist();
+
+    boolean getPadding();
+
+    String getPartOfSet();
+
+    String getPaymentUrl();
+
+    String getPublisher();
+
+    String getPublisherUrl();
+
+    String getRadiostationUrl();
+
+    String getUrl();
+
+    int getWmpRating();
+
+    boolean isCompilation();
+
+    boolean hasFooter();
+
+    boolean hasUnsynchronisation();
+
+}

--- a/src/main/java/com/mpatric/mp3agic/Mp3File.java
+++ b/src/main/java/com/mpatric/mp3agic/Mp3File.java
@@ -6,13 +6,15 @@ import java.io.RandomAccessFile;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Mp3File extends FileWrapper {
+public class Mp3File extends FileWrapper implements ID3v1Source {
 
 	private static final int DEFAULT_BUFFER_LENGTH = 65536;
 	private static final int MINIMUM_BUFFER_LENGTH = 40;
 	private static final int XING_MARKER_OFFSET_1 = 13;
 	private static final int XING_MARKER_OFFSET_2 = 21;
 	private static final int XING_MARKER_OFFSET_3 = 36;
+        
+        private static final ID3v1Source EMPTY_TAG = new EmptyID3v1Tag();
 
 	protected int bufferLength;
 	private int xingOffset = -1;
@@ -460,4 +462,98 @@ public class Mp3File extends FileWrapper {
 			randomAccessFile.close();
 		}
 	}
+
+    private ID3v1Source getAnyTag() {
+        return hasId3v2Tag() ? getId3v2Tag() : hasId3v1Tag() ? getId3v1Tag() : EMPTY_TAG;
+    }
+
+    @Override
+    public String getAlbum() {
+        return getAnyTag().getAlbum();
+    }
+
+    @Override
+    public String getArtist() {
+        return getAnyTag().getArtist();
+    }
+
+    @Override
+    public String getComment() {
+        return getAnyTag().getComment();
+    }
+
+    @Override
+    public int getGenre() {
+        return getAnyTag().getGenre();
+    }
+
+    @Override
+    public String getGenreDescription() {
+        return getAnyTag().getGenreDescription();
+    }
+
+    @Override
+    public String getTitle() {
+        return getAnyTag().getTitle();
+    }
+
+    @Override
+    public String getTrack() {
+        return getAnyTag().getTrack();
+    }
+
+    @Override
+    public String getYear() {
+        return getAnyTag().getYear();
+    }
+
+    private static class EmptyID3v1Tag implements ID3v1Source {
+
+        @Override
+        public String getAlbum() {
+            return null;
+        }
+
+        @Override
+        public String getArtist() {
+            return null;
+        }
+
+        @Override
+        public String getComment() {
+            return null;
+        }
+
+        @Override
+        public int getGenre() {
+            return 0;
+        }
+
+        @Override
+        public String getGenreDescription() {
+            return null;
+        }
+
+        @Override
+        public String getTitle() {
+            return null;
+        }
+
+        @Override
+        public String getTrack() {
+            return null;
+        }
+
+        @Override
+        public String getVersion() {
+            return null;
+        }
+
+        @Override
+        public String getYear() {
+            return null;
+        }
+
+    }
+
 }

--- a/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
+++ b/src/test/java/com/mpatric/mp3agic/Mp3FileTest.java
@@ -291,6 +291,82 @@ public class Mp3FileTest {
 		testShouldRemoveId3v1AndId3v2AndCustomTags(new Mp3File(filename));
 	}
 
+        @Test
+	public void shouldReadId3v1IfNoId3v2Present() throws Exception {
+		final Mp3File mp3File = new Mp3File();
+                
+                final ID3v1 id3v1 = new ID3v1Tag();
+                id3v1.setAlbum("v1 album");
+                id3v1.setArtist("v1 artist");
+                id3v1.setComment("v1 comment");
+                id3v1.setGenre(1);
+                id3v1.setTitle("v1 title");
+                id3v1.setTrack("v1 track");
+                id3v1.setYear("v1 year");
+
+                mp3File.setId3v1Tag(id3v1);
+                mp3File.setId3v2Tag(null);
+
+                assertEquals(id3v1.getAlbum(), mp3File.getAlbum());
+                assertEquals(id3v1.getArtist(), mp3File.getArtist());
+                assertEquals(id3v1.getComment(), mp3File.getComment());
+                assertEquals(id3v1.getGenre(), mp3File.getGenre());
+                assertEquals(id3v1.getGenreDescription(), mp3File.getGenreDescription());
+                assertEquals(id3v1.getTitle(), mp3File.getTitle());
+                assertEquals(id3v1.getTrack(), mp3File.getTrack());
+                assertEquals(id3v1.getYear(), mp3File.getYear());
+        }
+
+        @Test
+	public void shouldReadId3v2IfPresent() throws Exception {
+		final Mp3File mp3File = new Mp3File();
+                
+                final ID3v1 id3v1 = new ID3v1Tag();
+                id3v1.setAlbum("v1 album");
+                id3v1.setArtist("v1 artist");
+                id3v1.setComment("v1 comment");
+                id3v1.setGenre(1);
+                id3v1.setTitle("v1 title");
+                id3v1.setTrack("v1 track");
+                id3v1.setYear("v1 year");
+
+                final ID3v2 id3v2 = new ID3v22Tag();
+                id3v2.setAlbum("v2 album");
+                id3v2.setArtist("v2 artist");
+                id3v2.setComment("v2 comment");
+                id3v2.setGenre(2);
+                id3v2.setTitle("v2 title");
+                id3v2.setTrack("v2 track");
+                id3v2.setYear("v2 year");
+
+                mp3File.setId3v1Tag(id3v1);
+                mp3File.setId3v2Tag(id3v2);
+
+                assertEquals(id3v2.getAlbum(), mp3File.getAlbum());
+                assertEquals(id3v2.getArtist(), mp3File.getArtist());
+                assertEquals(id3v2.getComment(), mp3File.getComment());
+                assertEquals(id3v2.getGenre(), mp3File.getGenre());
+                assertEquals(id3v2.getGenreDescription(), mp3File.getGenreDescription());
+                assertEquals(id3v2.getTitle(), mp3File.getTitle());
+                assertEquals(id3v2.getTrack(), mp3File.getTrack());
+                assertEquals(id3v2.getYear(), mp3File.getYear());
+        }
+
+        @Test
+	public void shouldReturnEmptyValuesIfNoTagsPresent() throws Exception {
+		final Mp3File mp3File = new Mp3File();
+                mp3File.setId3v1Tag(null);
+                mp3File.setId3v2Tag(null);
+                assertNull(mp3File.getAlbum());
+                assertNull(mp3File.getArtist());
+                assertNull(mp3File.getComment());
+                assertEquals(0, mp3File.getGenre());
+                assertNull(mp3File.getGenreDescription());
+                assertNull(mp3File.getTitle());
+                assertNull(mp3File.getTrack());
+                assertNull(mp3File.getYear());
+	}
+
 	private void testShouldRemoveId3v1AndId3v2AndCustomTags(Mp3File mp3File) throws Exception {
 		String saveFilename = mp3File.getFilename() + ".copy";
 		try {


### PR DESCRIPTION
Extract read-only ID tag interfaces and provide convenience methods in Mp3File for reading tags.

Rationale: in many cases the library's client doesn't really care about all the tag details, it just has a mp3 file and wants to get metadata out of it, as easy as possible.
