### PR TITLE
Modify FileWrapperTest to pass on windows

### DIFF
--- a/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
+++ b/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.*;
@@ -52,20 +51,9 @@ public class FileWrapperTest {
 		new FileWrapper(NON_EXISTENT_FILENAME);
 	}
 
-	@Test
+	@Test(expected = FileNotFoundException.class)
 	public void shouldFailForMalformedFilename() throws IOException {
-		try {
-			new FileWrapper(MALFORMED_FILENAME);
-		}
-		// Linux/Mac
-		catch (FileNotFoundException fnfe) {
-			return;
-		}
-		// Windows
-		catch (InvalidPathException ipe) {
-			return;
-		}
-		fail("Expected FileNotFoundException or InvalidPathException");
+		new FileWrapper(MALFORMED_FILENAME);
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
+++ b/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.*;
@@ -51,9 +52,20 @@ public class FileWrapperTest {
 		new FileWrapper(NON_EXISTENT_FILENAME);
 	}
 
-	@Test(expected = FileNotFoundException.class)
+	@Test
 	public void shouldFailForMalformedFilename() throws IOException {
-		new FileWrapper(MALFORMED_FILENAME);
+		try {
+			new FileWrapper(MALFORMED_FILENAME);
+		}
+		// Linux/Mac
+		catch (FileNotFoundException fnfe) {
+			return;
+		}
+		// Windows
+		catch (InvalidPathException ipe) {
+			return;
+		}
+		fail("Expected FileNotFoundException or InvalidPathException");
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
+++ b/src/test/java/com/mpatric/mp3agic/FileWrapperTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.*;
@@ -14,7 +15,7 @@ public class FileWrapperTest {
 	private static final String VALID_FILENAME = "src" + fs + "test" + fs + "resources" + fs + "notags.mp3";
 	private static final long VALID_FILE_LENGTH = 2869;
 	private static final String NON_EXISTENT_FILENAME = "just-not.there";
-	private static final String MALFORMED_FILENAME = "malformed.?";
+	private static final String MALFORMED_FILENAME = "malformed.\0";
 
 	@Test
 	public void shouldReadValidFilename() throws IOException {
@@ -51,7 +52,7 @@ public class FileWrapperTest {
 		new FileWrapper(NON_EXISTENT_FILENAME);
 	}
 
-	@Test(expected = FileNotFoundException.class)
+	@Test(expected = InvalidPathException.class)
 	public void shouldFailForMalformedFilename() throws IOException {
 		new FileWrapper(MALFORMED_FILENAME);
 	}


### PR DESCRIPTION
For path being tested, windows platform reports `InvalidPathException` instead of `NotFoundException`.