### PR TITLE
comment frame data shoud have only one type of encoding; closes #131

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,3 +9,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - ID3Wrapper getGenre() returns v2 tag before v1 tag (instead of v1 tag before v2 tag).
 - ID3Wrapper getGenreDescription() returns v2 tag before v1 tag (instead of v1 tag before v2 tag).
+- ID3v2CommentFrameData constructor requires description and comment to have the same text encoding.

--- a/src/main/java/com/mpatric/mp3agic/ID3v2CommentFrameData.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2CommentFrameData.java
@@ -16,6 +16,9 @@ public class ID3v2CommentFrameData extends AbstractID3v2FrameData {
 
 	public ID3v2CommentFrameData(boolean unsynchronisation, String language, EncodedText description, EncodedText comment) {
 		super(unsynchronisation);
+		if (description != null && comment != null && description.getTextEncoding() != comment.getTextEncoding()) {
+			throw new IllegalArgumentException("description and comment must have same text encoding");
+		}
 		this.language = language;
 		this.description = description;
 		this.comment = comment;
@@ -67,7 +70,9 @@ public class ID3v2CommentFrameData extends AbstractID3v2FrameData {
 			BufferTools.copyIntoByteBuffer(descriptionBytes, 0, descriptionBytes.length, bytes, marker);
 			marker += descriptionBytes.length;
 		} else {
-			bytes[marker++] = 0;
+			byte[] terminatorBytes = comment != null ? comment.getTerminator() : new byte[]{0};
+			BufferTools.copyIntoByteBuffer(terminatorBytes, 0, terminatorBytes.length, bytes, marker);
+			marker += terminatorBytes.length;
 		}
 		if (comment != null) {
 			byte[] commentBytes = comment.toBytes(true, false);
@@ -80,7 +85,7 @@ public class ID3v2CommentFrameData extends AbstractID3v2FrameData {
 	protected int getLength() {
 		int length = 4;
 		if (description != null) length += description.toBytes(true, true).length;
-		else length++;
+		else length += comment != null ? comment.getTerminator().length : 1;
 		if (comment != null) length += comment.toBytes(true, false).length;
 		return length;
 	}

--- a/src/test/java/com/mpatric/mp3agic/ID3v2CommentFrameDataTest.java
+++ b/src/test/java/com/mpatric/mp3agic/ID3v2CommentFrameDataTest.java
@@ -133,6 +133,13 @@ public class ID3v2CommentFrameDataTest {
 		assertEquals(frameData, frameDataCopy);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorThrowsErrorWhenEncodingsDoNotMatch() {
+		new ID3v2CommentFrameData(false, TEST_LANGUAGE,
+				new EncodedText(EncodedText.TEXT_ENCODING_UTF_16, "description"),
+				new EncodedText(EncodedText.TEXT_ENCODING_UTF_8, "comment"));
+	}
+
 	@Test
 	public void shouldConvertFrameDataWithBlankDescriptionAndLanguageToBytesAndBackToEquivalentObject() throws Exception {
 		byte[] bytes = {0, 0, 0, 0, 0, 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q'};
@@ -151,6 +158,57 @@ public class ID3v2CommentFrameDataTest {
 		assertArrayEquals(expectedBytes, bytes);
 		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
 		assertEquals(frameData, frameDataCopy);
+	}
+
+	@Test
+	public void convertsEmptyFrameDataToBytesAndBack() throws Exception {
+		ID3v2CommentFrameData frameData = new ID3v2CommentFrameData(false, null, null, null);
+		byte[] bytes = frameData.toBytes();
+		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
+		assertEquals("eng", frameDataCopy.getLanguage());
+		assertEquals(new EncodedText(""), frameDataCopy.getDescription());
+		assertEquals(new EncodedText(""), frameDataCopy.getComment());
+	}
+
+	@Test
+	public void convertsFrameDataWithNoLanguageToBytesAndBack() throws Exception {
+		ID3v2CommentFrameData frameData = new ID3v2CommentFrameData(false, null, new EncodedText(TEST_DESCRIPTION), new EncodedText(TEST_VALUE));
+		byte[] bytes = frameData.toBytes();
+		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
+		assertEquals("eng", frameDataCopy.getLanguage());
+		assertEquals(new EncodedText(TEST_DESCRIPTION), frameDataCopy.getDescription());
+		assertEquals(new EncodedText(TEST_VALUE), frameDataCopy.getComment());
+	}
+
+	@Test
+	public void convertsFrameDataWithNoDescriptionToBytesAndBack() throws Exception {
+		ID3v2CommentFrameData frameData = new ID3v2CommentFrameData(false, TEST_LANGUAGE, null, new EncodedText(TEST_VALUE));
+		byte[] bytes = frameData.toBytes();
+		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
+		assertEquals("eng", frameDataCopy.getLanguage());
+		assertEquals(new EncodedText(""), frameDataCopy.getDescription());
+		assertEquals(new EncodedText(TEST_VALUE), frameDataCopy.getComment());
+	}
+
+	@Test
+	public void convertsFrameDataWithNoDescriptionAndCommentIsUnicodeToBytesAndBack() throws Exception {
+		ID3v2CommentFrameData frameData = new ID3v2CommentFrameData(false, TEST_LANGUAGE, null,
+				new EncodedText(EncodedText.TEXT_ENCODING_UTF_16, TEST_VALUE_UNICODE));
+		byte[] bytes = frameData.toBytes();
+		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
+		assertEquals("eng", frameDataCopy.getLanguage());
+		assertEquals(new EncodedText(EncodedText.TEXT_ENCODING_UTF_16, ""), frameDataCopy.getDescription());
+		assertEquals(new EncodedText(EncodedText.TEXT_ENCODING_UTF_16, TEST_VALUE_UNICODE), frameDataCopy.getComment());
+	}
+
+	@Test
+	public void convertsFrameDataWithNoCommentToBytesAndBack() throws Exception {
+		ID3v2CommentFrameData frameData = new ID3v2CommentFrameData(false, TEST_LANGUAGE, new EncodedText(TEST_DESCRIPTION), null);
+		byte[] bytes = frameData.toBytes();
+		ID3v2CommentFrameData frameDataCopy = new ID3v2CommentFrameData(false, bytes);
+		assertEquals("eng", frameDataCopy.getLanguage());
+		assertEquals(new EncodedText(TEST_DESCRIPTION), frameDataCopy.getDescription());
+		assertEquals(new EncodedText(""), frameDataCopy.getComment());
 	}
 
 	@Test


### PR DESCRIPTION
Hi @mpatric @hennr,

When packing frame data into bytes, if the `description` was null, then `0` was added for its null terminator. This doesn't work when `comment` is a text encoding with `00` as the null terminator - the `comment` encoding is the encoding that is chosen when packing frame data.

In the issue that was reported, the error occurred because `description` was null. But this will also happen if `description` and `comment` do not have the same encoding. Hence, I added a validation to the constructor to ensure they both have the same encoding.

I checked other frame data classes, but none of them had this issue.

