### PR TITLE
reorder order of operations in getLengthInMilliseconds to prevent int…

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/Mp3File.java
+++ b/src/main/java/com/mpatric/mp3agic/Mp3File.java
@@ -329,8 +329,7 @@ public class Mp3File extends FileWrapper {
 	}
 
 	public long getLengthInMilliseconds() {
-		double d = 8 * (endOffset - startOffset);
-		return (long) ((d / bitrate) + 0.5);
+		return (long) (((endOffset - startOffset) * (8.0 / bitrate)) + 0.5);
 	}
 
 	public long getLengthInSeconds() {


### PR DESCRIPTION
…eger overflow. This increases the maximum supported file size from 268 MB to 2.1 GB. closes #134 