### PR TITLE
Refactoring. Replaced Integer with primitive type int

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/Mp3File.java
+++ b/src/main/java/com/mpatric/mp3agic/Mp3File.java
@@ -258,7 +258,7 @@ public class Mp3File extends FileWrapper {
 	}
 
 	private void addBitrate(int bitrate) {
-		Integer key = new Integer(bitrate);
+                final int key = bitrate;
 		MutableInteger count = bitrates.get(key);
 		if (count != null) {
 			count.increment();


### PR DESCRIPTION
Replaced Integer with primitive type int.

- No need for primitive type wrapper as Java does autoboxing (when using the value as a key for the HashMap)

- In this method the value can never be null since the method parameter defines an int (primitive type). Thus Integer is not needed

- Since Integer is immutable `final int` was used to clarify that this value will never be changed.

- The Integer(int value) constructor is **deprecated** as of Java 9. The Javadocs(https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-) state:

> "It is rarely appropriate to use this constructor. The static factory valueOf(int) is generally a better choice, as it is likely to yield significantly better space and time performance."
