### PR TITLE
prevented instantiation and extension of classes that only have stati…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - ID3Wrapper getGenre() returns v2 tag before v1 tag (instead of v1 tag before v2 tag).
 - ID3Wrapper getGenreDescription() returns v2 tag before v1 tag (instead of v1 tag before v2 tag).
 - ID3v2CommentFrameData constructor requires description and comment to have the same text encoding.
+- BufferTools, ByteBufferUtils, ID3v1Genres, ID3v2TagFactory, and Version have no public constructor.

--- a/src/main/java/com/mpatric/mp3agic/BufferTools.java
+++ b/src/main/java/com/mpatric/mp3agic/BufferTools.java
@@ -2,9 +2,11 @@ package com.mpatric.mp3agic;
 
 import java.io.UnsupportedEncodingException;
 
-public class BufferTools {
+public final class BufferTools {
 
 	protected static final String defaultCharsetName = "ISO-8859-1";
+
+	private BufferTools() {}
 
 	public static String byteBufferToStringIgnoringEncodingIssues(byte[] bytes, int offset, int length) {
 		try {

--- a/src/main/java/com/mpatric/mp3agic/ByteBufferUtils.java
+++ b/src/main/java/com/mpatric/mp3agic/ByteBufferUtils.java
@@ -1,9 +1,10 @@
-
 package com.mpatric.mp3agic;
 
 import java.nio.ByteBuffer;
 
-public class ByteBufferUtils {
+public final class ByteBufferUtils {
+
+	private ByteBufferUtils() {}
 
 	public static String extractNullTerminatedString(ByteBuffer bb) {
 		int start = bb.position();
@@ -21,5 +22,4 @@ public class ByteBufferUtils {
 
 		return s;
 	}
-
 }

--- a/src/main/java/com/mpatric/mp3agic/ID3v1Genres.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v1Genres.java
@@ -1,6 +1,6 @@
 package com.mpatric.mp3agic;
 
-public class ID3v1Genres {
+public final class ID3v1Genres {
 	public static final String[] GENRES = {
 			"Blues",
 			"Classic Rock",
@@ -151,6 +151,8 @@ public class ID3v1Genres {
 			"JPop",
 			"Synthpop"
 	};
+
+	private ID3v1Genres() {}
 
 	/**
 	 * Match provided description against genres, ignoring case.

--- a/src/main/java/com/mpatric/mp3agic/ID3v2TagFactory.java
+++ b/src/main/java/com/mpatric/mp3agic/ID3v2TagFactory.java
@@ -1,6 +1,7 @@
 package com.mpatric.mp3agic;
 
-public class ID3v2TagFactory {
+public final class ID3v2TagFactory {
+	private ID3v2TagFactory() {}
 
 	public static AbstractID3v2Tag createTag(byte[] bytes) throws NoSuchTagException, UnsupportedTagException, InvalidDataException {
 		sanityCheckTag(bytes);

--- a/src/main/java/com/mpatric/mp3agic/Version.java
+++ b/src/main/java/com/mpatric/mp3agic/Version.java
@@ -1,6 +1,6 @@
 package com.mpatric.mp3agic;
 
-public class Version {
+public final class Version {
 	private static final String VERSION;
 	private static final String URL = "http://github.com/mpatric/mp3agic";
 
@@ -8,6 +8,8 @@ public class Version {
 		String implementationVersion = Version.class.getPackage().getImplementationVersion();
 		VERSION = implementationVersion != null ? implementationVersion : "UNKNOWN-SNAPSHOT";
 	}
+
+	private Version() {}
 
 	public static String asString() {
 		return getVersion() + " - " + getUrl();


### PR DESCRIPTION
…c methods

Since the 5 classes in this pull request contain only `static` methods, creating an instance of the class or extending the class is effectively useless.
Added `final` to the class definition to prevent extension.
Made the default constructor `private` to prevent instantiation.