### PR TITLE
MP3File filename

### DIFF
--- a/src/main/java/com/mpatric/mp3agic/FileWrapper.java
+++ b/src/main/java/com/mpatric/mp3agic/FileWrapper.java
@@ -41,6 +41,10 @@ public class FileWrapper {
 		lastModified = Files.getLastModifiedTime(path).to(TimeUnit.MILLISECONDS);
 	}
 
+	public String getName(){
+		return path.getFileName().toString();
+	}
+
 	public String getFilename() {
 		return path.toString();
 	}


### PR DESCRIPTION
The `getFileName` getter of `FileWrapper` is kind of misleading, since it returns the full file path instead of just the file's name. In order to not break projects having a dependency on this method, I added a method called `getName` which returns the actual filename. 

Maybe the two can be swapped in a future major release, which would make it clear to users that some things in the API have been changed. 