### PR TITLE
Allow inclusion as Android app module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+	defaultConfig {
+		minSdkVersion 26
+	}
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,6 @@ android {
         versionCode 1
         versionName "1.0"
     }
-//    buildTypes {
-//        release {
-//            minifyEnabled true
-//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-//        }
-//        debug {
-//            minifyEnabled false
-//        }
-//    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'com.android.library'
+
+group = 'com.mpatrick.mp3agic'
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+//    buildTypes {
+//        release {
+//            minifyEnabled true
+//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+//        }
+//        debug {
+//            minifyEnabled false
+//        }
+//    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,7 @@
 apply plugin: 'com.android.library'
 
-group = 'com.mpatrick.mp3agic'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest package="com.mpatrick.mp3agic">
+</manifest>


### PR DESCRIPTION
With those two files the library can be used as a module in Android apps.


The only requirement for the user is to add the following declaration in the app build.gradle file:
`ext {
    compileSdkVersion = 31
}`
